### PR TITLE
Feature/coveragerc

### DIFF
--- a/.coveragerc
+++ b/.coveragerc
@@ -1,0 +1,7 @@
+[run]
+omit =
+    */migrations/*
+    manage.py
+    */local_files/*
+    stockpot/wsgi.py
+    stockpot/asgi.py

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -161,6 +161,9 @@ jobs:
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v3
 
+      - name: Convert repository name to lowercase
+        run: echo "REPO_LC=$(echo ${{ github.repository }} | tr '[:upper:]' '[:lower:]')" >> $GITHUB_ENV
+
       - name: Log in to GitHub Container Registry
         uses: docker/login-action@v3
         # Skip login for PRs from forks (no access to secrets)
@@ -175,7 +178,7 @@ jobs:
         with:
           context: .
           push: ${{ !github.event.pull_request.head.repo.fork }}
-          tags: ghcr.io/${{ github.repository }}:${{ github.sha }}
+          tags: ghcr.io/${{ env.REPO_LC }}:${{ github.sha }}
           # Layer caching via GitHub Actions cache
           cache-from: type=gha
           cache-to: type=gha,mode=max
@@ -184,5 +187,5 @@ jobs:
         uses: anchore/sbom-action@v0
         if: ${{ !github.event.pull_request.head.repo.fork }}
         with:
-          image: ghcr.io/${{ github.repository }}:${{ github.sha }}
+          image: ghcr.io/${{ env.REPO_LC }}:${{ github.sha }}
           artifact-name: sbom-${{ github.sha }}.spdx.json

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -137,8 +137,7 @@ jobs:
             --cov=. \
             --cov-report=xml \
             --cov-report=term-missing \
-            --cov-fail-under=80 \
-            --cov-omit="*/migrations/*,manage.py,*/local_files/*,stockpot/wsgi.py,stockpot/asgi.py"
+            --cov-fail-under=80
 
       - name: Upload coverage report
         uses: actions/upload-artifact@v4


### PR DESCRIPTION
## Summary

This PR migrates code coverage settings from the command line to a dedicated `.coveragerc` file. This resolves a `pytest` error in the CI pipeline where the `--cov-omit` flag was being rejected as an unrecognized argument, causing the build to fail with exit code 4.

## Type of change

- [ ] 🐛 Bug fix
- [ ] ✨ New feature
- [ ] ♻️ Refactor (no functional change)
- [ ] 🧪 Tests only
- [ ] 📄 Documentation
- [x] 🔧 Configuration / DevOps

## Related issue(s)

Closes #15 

## Changes made

- Created a `.coveragerc` configuration file to manage coverage source and exclusions.
- Removed the `--cov-omit` arguments from the `pytest` execution command.

## Testing

- [ ] I have added or updated tests to cover my changes => **Doesn't apply**
- [x] All new and existing tests pass locally (`python manage.py test pantry`)
- [x] Test coverage has not dropped below 80 %

## CI checks

- [x] Python Lint (Flake8) passes
- [x] Frontend Lint (ESLint) passes
- [x] Security Scan (Bandit) passes
- [ ] Tests & Coverage gate passes
- [ ] Docker Build & Push succeeds
