### PR TITLE
Generalised HTML templates

### DIFF
--- a/stockpot/settings.py
+++ b/stockpot/settings.py
@@ -36,7 +36,7 @@ ROOT_URLCONF = "stockpot.urls"
 TEMPLATES = [
     {
         "BACKEND": "django.template.backends.django.DjangoTemplates",
-        "DIRS": [],
+        "DIRS": [BASE_DIR / "templates"],
         "APP_DIRS": True,
         "OPTIONS": {
             "context_processors": [

--- a/templates/base.html
+++ b/templates/base.html
@@ -1,0 +1,36 @@
+<!doctype html>
+<html lang="en">
+<head>
+  <meta charset="utf-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1">
+  <title>{% block title %}StockPot{% endblock %}</title>
+  <link href="https://cdn.jsdelivr.net/npm/bootstrap@5.3.3/dist/css/bootstrap.min.css"
+        rel="stylesheet"
+        integrity="sha384-QWTKZyjpPEjISv5WaRU9OFeRpok6YctnYmDr5pNlyT2bRjXh0JMhjY6hW+ALEwIH"
+        crossorigin="anonymous">
+</head>
+<body class="{% block body_class %}{% endblock %}">
+
+{% block page_heading %}{% endblock %}
+
+{% block navbar %}{% endblock %}
+
+{% block content %}{% endblock %}
+
+<script src="https://cdn.jsdelivr.net/npm/bootstrap@5.3.3/dist/js/bootstrap.bundle.min.js"
+        integrity="sha384-YvpcrYf0tY3lHB60NNkmXc4s9bIOgUxi8T/jzmkmIkWVfvTj7VRThXyPs2hDObQD"
+        crossorigin="anonymous"></script>
+<script>
+  // Available to all pages — reads from rendered {% csrf_token %} first, falls back to cookie.
+  function getCsrf() {
+    const token = document.querySelector('[name=csrfmiddlewaretoken]');
+    if (token) return token.value;
+    const match = document.cookie.match(/(?:^|;\s*)csrftoken=([^;]+)/);
+    return match ? decodeURIComponent(match[1]) : '';
+  }
+</script>
+
+{% block extra_js %}{% endblock %}
+
+</body>
+</html>

--- a/templates/base.html
+++ b/templates/base.html
@@ -21,7 +21,7 @@
         integrity="sha384-YvpcrYf0tY3lHB60NNkmXc4s9bIOgUxi8T/jzmkmIkWVfvTj7VRThXyPs2hDObQD"
         crossorigin="anonymous"></script>
 <script>
-  // Available to all pages — reads from rendered {% csrf_token %} first, falls back to cookie.
+  // Available to all pages. Reads from rendered {% csrf_token %} first, falls back to cookie.
   function getCsrf() {
     const token = document.querySelector('[name=csrfmiddlewaretoken]');
     if (token) return token.value;

--- a/users/templates/users/login.html
+++ b/users/templates/users/login.html
@@ -1,16 +1,10 @@
-<!doctype html>
-<html lang="en">
-<head>
-  <meta charset="utf-8">
-  <meta name="viewport" content="width=device-width, initial-scale=1">
-  <title>Log in – StockPot</title>
-  <link href="https://cdn.jsdelivr.net/npm/bootstrap@5.3.3/dist/css/bootstrap.min.css"
-        rel="stylesheet"
-        integrity="sha384-QWTKZyjpPEjISv5WaRU9OFeRpok6YctnYmDr5pNlyT2bRjXh0JMhjY6hW+ALEwIH"
-        crossorigin="anonymous">
-</head>
-<body class="bg-light">
+{% extends 'base.html' %}
 
+{% block title %}Log in – StockPot{% endblock %}
+
+{% block body_class %}bg-light{% endblock %}
+
+{% block content %}
 <div class="container d-flex justify-content-center align-items-center min-vh-100">
   <div class="card shadow-sm" style="width: 100%; max-width: 440px;">
     <div class="card-body p-4">
@@ -47,15 +41,13 @@
     </div>
   </div>
 </div>
+{% endblock %}
 
+{% block extra_js %}
 <script>
   const form = document.getElementById('login-form');
   const submitBtn = document.getElementById('submit-btn');
   const alertBox = document.getElementById('alert');
-
-  function getCsrf() {
-    return document.querySelector('[name=csrfmiddlewaretoken]').value;
-  }
 
   function showAlert(message, type = 'danger') {
     alertBox.className = `alert alert-${type}`;
@@ -77,18 +69,13 @@
     try {
       const response = await fetch('/api/auth/login/', {
         method: 'POST',
-        headers: {
-          'Content-Type': 'application/json',
-          'X-CSRFToken': getCsrf(),
-        },
+        headers: { 'Content-Type': 'application/json', 'X-CSRFToken': getCsrf() },
         body: JSON.stringify(payload),
       });
 
       if (response.ok) {
-        {#  Should be the dashboard but still not done #}
-        window.location.href = '/profile/';
+        window.location.href = '/dashboard/';
       } else {
-        // Use a generic message regardless of the server error to prevent enumeration
         showAlert('Invalid email or password. Please try again.');
       }
     } catch {
@@ -99,6 +86,4 @@
     }
   });
 </script>
-
-</body>
-</html>
+{% endblock %}

--- a/users/templates/users/profile.html
+++ b/users/templates/users/profile.html
@@ -1,32 +1,29 @@
-<!doctype html>
-<html lang="en">
-<head>
-  <meta charset="utf-8">
-  <meta name="viewport" content="width=device-width, initial-scale=1">
-  <title>Profile – StockPot</title>
-  <link href="https://cdn.jsdelivr.net/npm/bootstrap@5.3.3/dist/css/bootstrap.min.css"
-        rel="stylesheet"
-        integrity="sha384-QWTKZyjpPEjISv5WaRU9OFeRpok6YctnYmDr5pNlyT2bRjXh0JMhjY6hW+ALEwIH"
-        crossorigin="anonymous">
-</head>
-<body>
+{% extends 'base.html' %}
 
+{% block title %}Profile – StockPot{% endblock %}
+
+{% block page_heading %}
 <h1 class="px-4 pt-4 fw-bold fs-2">Profile</h1>
+{% endblock %}
 
+{% block navbar %}
 <nav class="navbar navbar-expand-lg navbar-light bg-white border-bottom px-4">
-  <a class="navbar-brand fw-bold" href="#">StockPot</a>
+  <a class="navbar-brand fw-bold" href="/dashboard/">StockPot</a>
   <button class="navbar-toggler" type="button" data-bs-toggle="collapse" data-bs-target="#navbarNav">
     <span class="navbar-toggler-icon"></span>
   </button>
   <div class="collapse navbar-collapse" id="navbarNav">
     <ul class="navbar-nav ms-auto">
-      <li class="nav-item">
-        <a class="nav-link" href="#" id="logout-link">Log out</a>
-      </li>
+      <li class="nav-item"><a class="nav-link" href="/dashboard/">Dashboard</a></li>
+      <li class="nav-item"><a class="nav-link" href="/pantry/">Pantry</a></li>
+      <li class="nav-item"><a class="nav-link active" href="/profile/">Profile</a></li>
+      <li class="nav-item"><a class="nav-link" href="#" id="logout-link">Log out</a></li>
     </ul>
   </div>
 </nav>
+{% endblock %}
 
+{% block content %}
 <div class="container py-5">
   <div class="mx-auto" style="max-width: 680px;">
 
@@ -41,30 +38,26 @@
         <form id="profile-form">
           {% csrf_token %}
 
-          <!-- Email -->
           <div class="mb-3">
             <label for="email" class="form-label">Email</label>
             <input type="text" class="form-control" id="email" name="email">
           </div>
 
-          <!-- Password -->
           <div class="mb-3">
             <label for="new_password" class="form-label">Password</label>
             <small class="d-block text-muted mb-1">Leave blank if not changing.</small>
             <input type="password" class="form-control" id="new_password" name="new_password" autocomplete="new-password">
           </div>
 
-          <!-- Password Confirmation -->
           <div class="mb-3">
             <label for="new_password2" class="form-label">Password Confirmation</label>
             <input type="password" class="form-control" id="new_password2" name="new_password2" autocomplete="new-password">
           </div>
 
-          <!-- Dietary Preferences -->
           <div class="mb-4">
             <h6 class="fw-semibold">Dietary Preferences</h6>
             <small class="text-muted">This configuration will be used as your default filters but can be modified before searching.</small>
-            <div id="dietary-list" class="mt-2">
+            <div class="mt-2">
               {% for key, label in dietary_choices %}
               <div class="form-check">
                 <input class="form-check-input dietary-checkbox" type="checkbox" value="{{ key }}" id="diet-{{ key }}">
@@ -83,16 +76,11 @@
 
   </div>
 </div>
+{% endblock %}
 
-<script src="https://cdn.jsdelivr.net/npm/bootstrap@5.3.3/dist/js/bootstrap.bundle.min.js"
-        integrity="sha384-YvpcrYf0tY3lHB60NNkmXc4s9bIOgUxi8T/jzmkmIkWVfvTj7VRThXyPs2hDObQD"
-        crossorigin="anonymous"></script>
+{% block extra_js %}
 <script>
   const PROFILE_URL = '/api/auth/profile/';
-
-  function getCsrf() {
-    return document.querySelector('[name=csrfmiddlewaretoken]').value;
-  }
 
   function showAlert(msg, type = 'danger') {
     document.getElementById('alert-area').innerHTML =
@@ -102,7 +90,6 @@
        </div>`;
   }
 
-  // Load current profile data
   fetch(PROFILE_URL, { credentials: 'same-origin' })
     .then(r => r.json())
     .then(data => {
@@ -130,10 +117,7 @@
       document.querySelectorAll('.dietary-checkbox:checked')
     ).map(cb => cb.value);
 
-    const payload = {
-      email: document.getElementById('email').value.trim(),
-      dietary_preferences,
-    };
+    const payload = { email: document.getElementById('email').value.trim(), dietary_preferences };
 
     const newPw = document.getElementById('new_password').value;
     const newPw2 = document.getElementById('new_password2').value;
@@ -145,17 +129,13 @@
     fetch(PROFILE_URL, {
       method: 'PATCH',
       credentials: 'same-origin',
-      headers: {
-        'Content-Type': 'application/json',
-        'X-CSRFToken': getCsrf(),
-      },
+      headers: { 'Content-Type': 'application/json', 'X-CSRFToken': getCsrf() },
       body: JSON.stringify(payload),
     })
       .then(async r => {
         if (!r.ok) {
           const err = await r.json();
-          const msgs = Object.values(err).flat().join(' ');
-          showAlert(msgs);
+          showAlert(Object.values(err).flat().join(' '));
         } else {
           showAlert('Profile updated successfully.', 'success');
           document.getElementById('new_password').value = '';
@@ -165,5 +145,4 @@
       .catch(() => showAlert('An error occurred. Please try again.'));
   });
 </script>
-</body>
-</html>
+{% endblock %}

--- a/users/templates/users/register.html
+++ b/users/templates/users/register.html
@@ -1,16 +1,10 @@
-<!doctype html>
-<html lang="en">
-<head>
-  <meta charset="utf-8">
-  <meta name="viewport" content="width=device-width, initial-scale=1">
-  <title>Create account – StockPot</title>
-  <link href="https://cdn.jsdelivr.net/npm/bootstrap@5.3.3/dist/css/bootstrap.min.css"
-        rel="stylesheet"
-        integrity="sha384-QWTKZyjpPEjISv5WaRU9OFeRpok6YctnYmDr5pNlyT2bRjXh0JMhjY6hW+ALEwIH"
-        crossorigin="anonymous">
-</head>
-<body class="bg-light">
+{% extends 'base.html' %}
 
+{% block title %}Create account – StockPot{% endblock %}
+
+{% block body_class %}bg-light{% endblock %}
+
+{% block content %}
 <div class="container d-flex justify-content-center align-items-center min-vh-100">
   <div class="card shadow-sm" style="width: 100%; max-width: 440px;">
     <div class="card-body p-4">
@@ -51,25 +45,19 @@
     </div>
   </div>
 </div>
+{% endblock %}
 
+{% block extra_js %}
 <script>
   const form = document.getElementById('register-form');
   const submitBtn = document.getElementById('submit-btn');
   const alertBox = document.getElementById('alert');
 
-  function getCsrf() {
-    return document.querySelector('[name=csrfmiddlewaretoken]').value;
-  }
-
   function clearErrors() {
     alertBox.className = 'alert d-none';
     alertBox.textContent = '';
-    form.querySelectorAll('.form-control').forEach(el => {
-      el.classList.remove('is-invalid', 'is-valid');
-    });
-    document.querySelectorAll('.invalid-feedback').forEach(el => {
-      el.textContent = '';
-    });
+    form.querySelectorAll('.form-control').forEach(el => el.classList.remove('is-invalid', 'is-valid'));
+    document.querySelectorAll('.invalid-feedback').forEach(el => { el.textContent = ''; });
   }
 
   function showFieldError(fieldName, messages) {
@@ -100,10 +88,7 @@
     try {
       const response = await fetch('/api/auth/register/', {
         method: 'POST',
-        headers: {
-          'Content-Type': 'application/json',
-          'X-CSRFToken': getCsrf(),
-        },
+        headers: { 'Content-Type': 'application/json', 'X-CSRFToken': getCsrf() },
         body: JSON.stringify(payload),
       });
 
@@ -113,19 +98,13 @@
         form.classList.add('d-none');
         showAlert(`Account created for ${data.email}. You can now log in.`, 'success');
       } else {
-        // Map field-level errors returned by DRF back to the form inputs.
         const fieldNames = ['email', 'password', 'password2'];
         let hasFieldError = false;
         fieldNames.forEach(field => {
-          if (data[field]) {
-            showFieldError(field, data[field]);
-            hasFieldError = true;
-          }
+          if (data[field]) { showFieldError(field, data[field]); hasFieldError = true; }
         });
-        // Fall back to a generic alert for non-field errors.
         if (!hasFieldError) {
-          const msg = data.detail || data.non_field_errors?.join(' ') || 'Registration failed. Please try again.';
-          showAlert(msg);
+          showAlert(data.detail || data.non_field_errors?.join(' ') || 'Registration failed. Please try again.');
         }
       }
     } catch {
@@ -136,6 +115,4 @@
     }
   });
 </script>
-
-</body>
-</html>
+{% endblock %}


### PR DESCRIPTION
## Summary

Generalise HTML templates to avoid code duplication

## Type of change

- [ ] Bug fix
- [ ] New feature
- [x]️ Refactor (no functional change)
- [ ] Tests only
- [ ] Documentation
- [ ] Configuration / DevOps

## Related issue(s)

Closes #35 

## Changes made


- `templates/base.html` created. Standard skeleton with Bootstrap 5.3.3 CDN (CSS + JS)
    - Defines blocks: `title`, `body_class`, `page_heading`, `navbar`, `content`, `extra_js`
    - Includes a shared `getCsrf()` helper function available to all child pages to use in forms.
- `stockpot/settings.py` uses `TEMPLATES[0]["DIRS"]` so Django finds the project-level `base.html`
- All existing HTML set to extend `base.html`

## Testing

- [x] I have added or updated tests to cover my changes
- [x] All new and existing tests pass locally (`python manage.py test pantry`)
- [x] Test coverage has not dropped below 80 %

