### PR TITLE
Feature/fr7 spoonacular integration

### DIFF
--- a/pantry/services.py
+++ b/pantry/services.py
@@ -1,0 +1,75 @@
+import requests
+from django.conf import settings
+
+SPOONACULAR_BASE_URL = "https://api.spoonacular.com"
+TIMEOUT = 10  # Timeout in seconds
+
+
+class SpoonacularError(Exception):
+    """
+    Raised when the Spoonacular API returns an unexpected response.
+    """
+    def __init__(self, message, status_code=None):
+        super().__init__(message)
+        self.status_code = status_code
+
+
+def find_recipes_by_ingredients(ingredient_names: list[str], number: int = 12) -> list[dict]:
+    """
+    Request to Spoonacular /recipes/findByIngredients endpoint.
+
+    Args:
+        ingredient_names    - List of ingredient name strings from the user's pantry.
+        number              - Maximum number of recipes to return (defaults to 12).
+
+    Returns a list of recipe dicts, each containing:
+            id, title, image, used_count, missed_count,
+            used_ingredients (list of names), missed_ingredients (list of names)
+
+    Raises a SpoonacularError if the API key is missing, the API is unreachable, or the API returns a non-200 response.
+    """
+
+    api_key = settings.SPOONACULAR_API_KEY
+    if not api_key:
+        raise SpoonacularError("Spoonacular API key is not configured. Set SPOONACULAR_API_KEY in your environment.")
+
+    try:
+        response = requests.get(
+            f"{SPOONACULAR_BASE_URL}/recipes/findByIngredients",
+            params={
+                "ingredients": ",".join(ingredient_names),
+                "number": number,
+                "ranking": 1,       # Spoonacular option to maximise used ingredients
+                "ignorePantry": True,
+                "apiKey": api_key,
+            },
+            timeout=TIMEOUT,
+        )
+    except requests.exceptions.Timeout:
+        raise SpoonacularError("The recipe service timed out. Please try again.")
+    except requests.exceptions.RequestException as e:
+        raise SpoonacularError(f"Could not reach the recipe service: {e}")
+
+    if response.status_code == 402:
+        raise SpoonacularError("Recipe API quota exceeded. Please try again later.", status_code=402)
+
+    if not response.ok:
+        raise SpoonacularError(
+            f"Recipe service returned an error (HTTP {response.status_code}).",
+            status_code=response.status_code,
+        )
+
+    raw = response.json()
+
+    return [
+        {
+            "id": item["id"],
+            "title": item["title"],
+            "image": item.get("image", ""),
+            "used_count": item.get("usedIngredientCount", 0),
+            "missed_count": item.get("missedIngredientCount", 0),
+            "used_ingredients": [i["name"] for i in item.get("usedIngredients", [])],
+            "missed_ingredients": [i["name"] for i in item.get("missedIngredients", [])],
+        }
+        for item in raw
+    ]

--- a/pantry/templates/pantry/recipes.html
+++ b/pantry/templates/pantry/recipes.html
@@ -1,0 +1,150 @@
+{% extends 'base.html' %}
+
+{% block title %}Recipes – StockPot{% endblock %}
+
+{% block content %}
+<div class="container py-4">
+
+  <div class="d-flex justify-content-between align-items-center mb-4">
+    <h4 class="fw-bold mb-0">Recipe Suggestions</h4>
+    <button class="btn btn-primary" id="btn-find-recipes">
+      Find Recipes
+    </button>
+  </div>
+
+  <div id="alert-area"></div>
+
+  <!-- Loading spinner -->
+  <div id="loading" class="text-center py-5 d-none">
+    <div class="spinner-border text-primary" role="status">
+      <span class="visually-hidden">Loading…</span>
+    </div>
+    <p class="text-muted mt-2">Searching for recipes…</p>
+  </div>
+
+  <!-- Recipe cards -->
+  <div class="row g-4" id="recipe-grid"></div>
+
+  <!-- Empty state -->
+  <div id="empty-state" class="text-center text-muted py-5 d-none">
+    <p class="mb-1">No recipes found for your current pantry.</p>
+    <p class="small">Try adding more ingredients to get better suggestions.</p>
+  </div>
+
+</div>
+{% endblock %}
+
+{% block extra_js %}
+<script>
+  const MATCH_URL = '/api/recipes/match/';
+  const SPOONACULAR_RECIPES_URL = 'https://spoonacular.com/recipes/';
+
+  function showAlert(msg, type = 'danger') {
+    document.getElementById('alert-area').innerHTML =
+      `<div class="alert alert-${type} alert-dismissible fade show" role="alert">
+        ${msg}
+        <button type="button" class="btn-close" data-bs-dismiss="alert"></button>
+       </div>`;
+  }
+
+  function clearAlert() {
+    document.getElementById('alert-area').innerHTML = '';
+  }
+
+  function setLoading(on) {
+    document.getElementById('loading').classList.toggle('d-none', !on);
+    document.getElementById('btn-find-recipes').disabled = on;
+  }
+
+  function renderRecipes(recipes) {
+    const grid = document.getElementById('recipe-grid');
+    const empty = document.getElementById('empty-state');
+    grid.innerHTML = '';
+
+    if (!recipes.length) {
+      empty.classList.remove('d-none');
+      return;
+    }
+    empty.classList.add('d-none');
+
+    recipes.forEach(r => {
+      const usedBadge  = `<span class="badge bg-success me-1">${r.used_count} in pantry</span>`;
+      const missBadge  = r.missed_count
+        ? `<span class="badge bg-secondary">${r.missed_count} missing</span>`
+        : '';
+      const usedList   = r.used_ingredients.length
+        ? `<p class="small text-muted mb-1"><strong>Have:</strong> ${r.used_ingredients.join(', ')}</p>`
+        : '';
+      const missList   = r.missed_ingredients.length
+        ? `<p class="small text-muted mb-0"><strong>Missing:</strong> ${r.missed_ingredients.join(', ')}</p>`
+        : '';
+      const imgHtml    = r.image
+        ? `<img src="${r.image}" class="card-img-top" alt="${r.title}" style="height:180px;object-fit:cover;">`
+        : `<div class="bg-light d-flex align-items-center justify-content-center" style="height:180px;">
+             <span class="text-muted">No image</span>
+           </div>`;
+
+      const col = document.createElement('div');
+      col.className = 'col-sm-6 col-lg-4';
+      col.innerHTML = `
+        <div class="card h-100 shadow-sm">
+          <a href="${SPOONACULAR_RECIPES_URL}${encodeURIComponent(r.title.toLowerCase().replace(/\s+/g, '-'))}-${r.id}"
+             target="_blank" rel="noopener noreferrer" class="text-decoration-none text-dark">
+            ${imgHtml}
+          </a>
+          <div class="card-body d-flex flex-column">
+            <h6 class="card-title fw-semibold mb-2">
+              <a href="${SPOONACULAR_RECIPES_URL}${encodeURIComponent(r.title.toLowerCase().replace(/\s+/g, '-'))}-${r.id}"
+                 target="_blank" rel="noopener noreferrer" class="text-decoration-none text-dark">
+                ${r.title}
+              </a>
+            </h6>
+            <div class="mb-2">${usedBadge}${missBadge}</div>
+            ${usedList}${missList}
+          </div>
+        </div>`;
+      grid.appendChild(col);
+    });
+  }
+
+  document.getElementById('btn-find-recipes').addEventListener('click', async () => {
+    clearAlert();
+    setLoading(true);
+    document.getElementById('recipe-grid').innerHTML = '';
+    document.getElementById('empty-state').classList.add('d-none');
+
+    try {
+      const resp = await fetch(MATCH_URL, { credentials: 'same-origin' });
+      const data = await resp.json();
+
+      if (!resp.ok) {
+        const msg = data.detail || 'An error occurred while fetching recipes.';
+        const type = resp.status === 429 ? 'warning' : 'danger';
+        showAlert(msg, type);
+        return;
+      }
+
+      // Handle pantry-empty message returned as 200
+      if (data.detail) {
+        showAlert(data.detail, 'info');
+        return;
+      }
+
+      renderRecipes(data);
+    } catch {
+      showAlert('Could not reach the recipe service. Please check your connection and try again.');
+    } finally {
+      setLoading(false);
+    }
+  });
+
+  document.getElementById('logout-link').addEventListener('click', e => {
+    e.preventDefault();
+    fetch('/api/auth/logout/', {
+      method: 'POST',
+      credentials: 'same-origin',
+      headers: { 'X-CSRFToken': getCsrf() },
+    }).then(() => { window.location.href = '/login/'; });
+  });
+</script>
+{% endblock %}

--- a/pantry/tests/test_services.py
+++ b/pantry/tests/test_services.py
@@ -1,0 +1,125 @@
+from unittest.mock import patch
+
+import requests
+from django.test import TestCase, override_settings
+from pantry.services import SpoonacularError, find_recipes_by_ingredients
+
+
+class SpoonacularServiceTest(TestCase):
+
+    def setUp(self):
+        self.sample_api_response = [
+            {
+                "id": 1,
+                "title": "Pancakes",
+                "image": "https://example.com/pancakes.jpg",
+                "usedIngredientCount": 2,
+                "missedIngredientCount": 1,
+                "usedIngredients": [{"name": "Flour"}, {"name": "Milk"}],
+                "missedIngredients": [{"name": "Eggs"}],
+            }
+        ]
+        self.expected_recipe = {
+            "id": 1,
+            "title": "Pancakes",
+            "image": "https://example.com/pancakes.jpg",
+            "used_count": 2,
+            "missed_count": 1,
+            "used_ingredients": ["Flour", "Milk"],
+            "missed_ingredients": ["Eggs"],
+        }
+
+    @override_settings(SPOONACULAR_API_KEY="")
+    def test_raises_when_api_key_is_not_configured(self):
+        with self.assertRaises(SpoonacularError) as context:
+            find_recipes_by_ingredients(["Flour"])
+        self.assertIn("API key", str(context.exception))
+
+    @override_settings(SPOONACULAR_API_KEY="test-key")
+    @patch("pantry.services.requests.get")
+    def test_returns_normalised_recipe_list_on_success(self, mock_get):
+        mock_get.return_value.ok = True
+        mock_get.return_value.status_code = 200
+        mock_get.return_value.json.return_value = self.sample_api_response
+
+        result = find_recipes_by_ingredients(["Flour", "Milk"])
+
+        self.assertEqual(result, [self.expected_recipe])
+
+    @override_settings(SPOONACULAR_API_KEY="test-key")
+    @patch("pantry.services.requests.get")
+    def test_passes_ingredients_as_comma_joined_string(self, mock_get):
+        mock_get.return_value.ok = True
+        mock_get.return_value.status_code = 200
+        mock_get.return_value.json.return_value = []
+
+        find_recipes_by_ingredients(["Flour", "Milk", "Eggs"])
+
+        sent_ingredients = mock_get.call_args.kwargs["params"]["ingredients"]
+        self.assertEqual(sent_ingredients, "Flour,Milk,Eggs")
+
+    @override_settings(SPOONACULAR_API_KEY="test-key")
+    @patch("pantry.services.requests.get")
+    def test_raises_spoonacular_error_on_402(self, mock_get):
+        mock_get.return_value.ok = False
+        mock_get.return_value.status_code = 402
+
+        with self.assertRaises(SpoonacularError) as context:
+            find_recipes_by_ingredients(["Flour"])
+
+        self.assertEqual(context.exception.status_code, 402)
+
+    @override_settings(SPOONACULAR_API_KEY="test-key")
+    @patch("pantry.services.requests.get")
+    def test_raises_spoonacular_error_on_non_200_response(self, mock_get):
+        mock_get.return_value.ok = False
+        mock_get.return_value.status_code = 500
+
+        with self.assertRaises(SpoonacularError) as context:
+            find_recipes_by_ingredients(["Flour"])
+
+        self.assertEqual(context.exception.status_code, 500)
+
+    @override_settings(SPOONACULAR_API_KEY="test-key")
+    @patch("pantry.services.requests.get")
+    def test_raises_spoonacular_error_on_timeout(self, mock_get):
+        mock_get.side_effect = requests.exceptions.Timeout
+
+        with self.assertRaises(SpoonacularError) as context:
+            find_recipes_by_ingredients(["Flour"])
+
+        self.assertIn("timed out", str(context.exception))
+
+    @override_settings(SPOONACULAR_API_KEY="test-key")
+    @patch("pantry.services.requests.get")
+    def test_raises_spoonacular_error_on_network_failure(self, mock_get):
+        mock_get.side_effect = requests.exceptions.ConnectionError("unreachable")
+
+        with self.assertRaises(SpoonacularError) as context:
+            find_recipes_by_ingredients(["Flour"])
+
+        self.assertIn("Could not reach", str(context.exception))
+
+    @override_settings(SPOONACULAR_API_KEY="test-key")
+    @patch("pantry.services.requests.get")
+    def test_returns_empty_list_when_api_returns_no_results(self, mock_get):
+        mock_get.return_value.ok = True
+        mock_get.return_value.status_code = 200
+        mock_get.return_value.json.return_value = []
+
+        result = find_recipes_by_ingredients(["UnknownIngredient"])
+
+        self.assertEqual(result, [])
+
+    @override_settings(SPOONACULAR_API_KEY="test-key")
+    @patch("pantry.services.requests.get")
+    def test_recipe_without_image_defaults_to_empty_string(self, mock_get):
+        api_response = [{**self.sample_api_response[0]}]
+        del api_response[0]["image"]
+        mock_get.return_value.ok = True
+        mock_get.return_value.status_code = 200
+        mock_get.return_value.json.return_value = api_response
+
+        result = find_recipes_by_ingredients(["Flour"])
+
+        self.assertEqual(result[0]["image"], "")

--- a/pantry/tests/test_views.py
+++ b/pantry/tests/test_views.py
@@ -1,16 +1,12 @@
 import datetime
-
 from django.contrib.auth.models import User
 from django.urls import reverse
 from django.test import TestCase
 from rest_framework import status
 from rest_framework.test import APITestCase
-
 from unittest.mock import patch
-
 from pantry.models import Ingredient, StockItem
 from pantry.services import SpoonacularError
-
 
 
 class IngredientListCreateViewTest(APITestCase):
@@ -343,7 +339,6 @@ class StockItemDetailViewTest(APITestCase):
         self.client.force_authenticate(user=None)
         response = self.client.delete(self.url)
         self.assertEqual(response.status_code, status.HTTP_403_FORBIDDEN)
-
 
 
 class RecipeMatchViewTest(APITestCase):

--- a/pantry/tests/test_views.py
+++ b/pantry/tests/test_views.py
@@ -2,10 +2,15 @@ import datetime
 
 from django.contrib.auth.models import User
 from django.urls import reverse
+from django.test import TestCase
 from rest_framework import status
 from rest_framework.test import APITestCase
 
+from unittest.mock import patch
+
 from pantry.models import Ingredient, StockItem
+from pantry.services import SpoonacularError
+
 
 
 class IngredientListCreateViewTest(APITestCase):
@@ -338,3 +343,125 @@ class StockItemDetailViewTest(APITestCase):
         self.client.force_authenticate(user=None)
         response = self.client.delete(self.url)
         self.assertEqual(response.status_code, status.HTTP_403_FORBIDDEN)
+
+
+
+class RecipeMatchViewTest(APITestCase):
+
+    def setUp(self):
+        self.user = User.objects.create_user(username="test@email.com", password="SecurePass123!")
+        self.other_user = User.objects.create_user(username="othertest@email.com", password="SecurePass234!")
+        self.client.force_authenticate(user=self.user)
+        self.flour = Ingredient.objects.create(name="Flour", unit="g")
+        self.milk = Ingredient.objects.create(name="Milk", unit="L")
+        self.url = reverse("recipe-match")
+        self.expected_recipe = {
+            "id": 1,
+            "title": "Pancakes",
+            "image": "https://example.com/pancakes.jpg",
+            "used_count": 2,
+            "missed_count": 1,
+            "used_ingredients": ["Flour", "Milk"],
+            "missed_ingredients": ["Eggs"],
+        }
+
+    def test_requires_authentication(self):
+        self.client.force_authenticate(user=None)
+        response = self.client.get(self.url)
+        self.assertEqual(response.status_code, status.HTTP_403_FORBIDDEN)
+
+    def test_empty_pantry_returns_200_with_detail_message(self):
+        response = self.client.get(self.url)
+        self.assertEqual(response.status_code, status.HTTP_200_OK)
+        self.assertIn("detail", response.data)
+        self.assertIn("empty", response.data["detail"].lower())
+
+    @patch("pantry.views.find_recipes_by_ingredients")
+    def test_returns_recipes_when_pantry_has_items(self, mock_service):
+        mock_service.return_value = [self.expected_recipe]
+        StockItem.objects.create(user=self.user, ingredient=self.flour, quantity=500)
+        StockItem.objects.create(user=self.user, ingredient=self.milk, quantity=1)
+
+        response = self.client.get(self.url)
+
+        self.assertEqual(response.status_code, status.HTTP_200_OK)
+        self.assertEqual(len(response.data), 1)
+        self.assertEqual(response.data[0]["title"], "Pancakes")
+
+    @patch("pantry.views.find_recipes_by_ingredients")
+    def test_only_sends_logged_user_ingredients_to_service(self, mock_service):
+        mock_service.return_value = [self.expected_recipe]
+        StockItem.objects.create(user=self.user, ingredient=self.flour, quantity=500)
+        StockItem.objects.create(user=self.other_user, ingredient=self.milk, quantity=1)
+
+        self.client.get(self.url)
+
+        sent_names = mock_service.call_args[0][0]
+        self.assertEqual(sent_names, ["Flour"])
+
+    @patch(
+        "pantry.views.find_recipes_by_ingredients",
+        side_effect=SpoonacularError("quota exceeded", status_code=402),
+    )
+    def test_quota_exceeded_returns_402(self, mock_service):
+        StockItem.objects.create(user=self.user, ingredient=self.flour, quantity=500)
+        response = self.client.get(self.url)
+        self.assertEqual(response.status_code, status.HTTP_429_TOO_MANY_REQUESTS)
+        self.assertIn("detail", response.data)
+
+    @patch(
+        "pantry.views.find_recipes_by_ingredients",
+        side_effect=SpoonacularError("service unavailable", status_code=503),
+    )
+    def test_other_service_errors_return_503(self, mock_service):
+        StockItem.objects.create(user=self.user, ingredient=self.flour, quantity=500)
+        response = self.client.get(self.url)
+        self.assertEqual(response.status_code, status.HTTP_503_SERVICE_UNAVAILABLE)
+
+    @patch(
+        "pantry.views.find_recipes_by_ingredients",
+        side_effect=SpoonacularError("timed out"),
+    )
+    def test_service_error_without_status_code_returns_503(self, mock_service):
+        StockItem.objects.create(user=self.user, ingredient=self.flour, quantity=500)
+        response = self.client.get(self.url)
+        self.assertEqual(response.status_code, status.HTTP_503_SERVICE_UNAVAILABLE)
+
+    @patch("pantry.views.find_recipes_by_ingredients", return_value=[])
+    def test_returns_empty_list_when_no_matching_recipes(self, mock_service):
+        StockItem.objects.create(user=self.user, ingredient=self.flour, quantity=500)
+        response = self.client.get(self.url)
+        self.assertEqual(response.status_code, status.HTTP_200_OK)
+        self.assertEqual(response.data, [])
+
+
+class RecipeSuggestionsPageViewTest(TestCase):
+
+    def setUp(self):
+        self.user = User.objects.create_user(username="test@email.com", password="SecurePass123!")
+        self.url = reverse("recipes-page")
+
+    def test_renders_recipes_template(self):
+        self.client.force_login(self.user)
+        response = self.client.get(self.url)
+        self.assertEqual(response.status_code, 200)
+        self.assertTemplateUsed(response, "pantry/recipes.html")
+
+
+class PantryPageViewTest(TestCase):
+
+    def setUp(self):
+        self.user = User.objects.create_user(username="test@email.com", password="SecurePass123!")
+        self.url = reverse("pantry-page")
+
+    def test_renders_stock_template(self):
+        self.client.force_login(self.user)
+        response = self.client.get(self.url)
+        self.assertEqual(response.status_code, 200)
+        self.assertTemplateUsed(response, "pantry/stock.html")
+
+    def test_context_includes_unit_choices(self):
+        self.client.force_login(self.user)
+        response = self.client.get(self.url)
+        self.assertIn("unit_choices", response.context)
+        self.assertTrue(len(response.context["unit_choices"]) > 0)

--- a/pantry/urls.py
+++ b/pantry/urls.py
@@ -1,8 +1,9 @@
 from django.urls import path
-from .views import IngredientListCreateView, StockItemListCreateView, StockItemDetailView
+from .views import IngredientListCreateView, RecipeMatchView, StockItemListCreateView, StockItemDetailView
 
 urlpatterns = [
     path("ingredients/", IngredientListCreateView.as_view(), name="ingredient-list-create"),
     path("stock/", StockItemListCreateView.as_view(), name="stock-list-create"),
     path("stock/<int:pk>/", StockItemDetailView.as_view(), name="stock-detail"),
+    path("recipes/match/", RecipeMatchView.as_view(), name="recipe-match"),
 ]

--- a/pantry/views.py
+++ b/pantry/views.py
@@ -103,3 +103,11 @@ class RecipeMatchView(APIView):
             return Response({"detail": str(e)}, status=http_status)
 
         return Response(recipes, status=status.HTTP_200_OK)
+
+
+class RecipeSuggestionsPageView(TemplateView):
+    """
+    GET /recipes/
+    Recipe suggestions HTML page.
+    """
+    template_name = "pantry/recipes.html"

--- a/pantry/views.py
+++ b/pantry/views.py
@@ -1,8 +1,11 @@
-from rest_framework import generics, filters
+from rest_framework import generics, filters, status
 from rest_framework.permissions import IsAuthenticated
+from rest_framework.response import Response
+from rest_framework.views import APIView
 
 from .models import Ingredient, StockItem
 from .serializers import IngredientSerializer, StockItemReadSerializer, StockItemWriteSerializer
+from .services import SpoonacularError, find_recipes_by_ingredients
 from django.views.generic import TemplateView
 
 
@@ -69,3 +72,34 @@ class PantryPageView(TemplateView):
         context = super().get_context_data(**kwargs)
         context["unit_choices"] = Ingredient.Unit.choices
         return context
+
+
+class RecipeMatchView(APIView):
+    """
+    GET /api/recipes/match/
+    Returns recipe suggestions from Spoonacular based on the user's current pantry.
+    """
+    permission_classes = [IsAuthenticated]
+
+    def get(self, request):
+        ingredient_names = list(
+            StockItem.objects.filter(user=request.user)
+            .select_related("ingredient")
+            .values_list("ingredient__name", flat=True)
+        )
+
+        if not ingredient_names:
+            return Response(
+                {"detail": "Your pantry is empty. Add some ingredients to get recipe suggestions."},
+                status=status.HTTP_200_OK,
+            )
+
+        try:
+            recipes = find_recipes_by_ingredients(ingredient_names)
+        except SpoonacularError as e:
+            http_status = status.HTTP_503_SERVICE_UNAVAILABLE
+            if e.status_code == 402:
+                http_status = status.HTTP_429_TOO_MANY_REQUESTS
+            return Response({"detail": str(e)}, status=http_status)
+
+        return Response(recipes, status=status.HTTP_200_OK)

--- a/requirements.txt
+++ b/requirements.txt
@@ -3,3 +3,4 @@ djangorestframework==3.17.1
 psycopg2-binary==2.9.12
 gunicorn==25.3.0
 python-decouple==3.8
+requests==2.32.3

--- a/stockpot/settings.py
+++ b/stockpot/settings.py
@@ -79,6 +79,8 @@ STATIC_ROOT = BASE_DIR / "staticfiles"
 
 DEFAULT_AUTO_FIELD = "django.db.models.BigAutoField"
 
+SPOONACULAR_API_KEY = config("SPOONACULAR_API_KEY", default="")
+
 REST_FRAMEWORK = {
     "DEFAULT_RENDERER_CLASSES": [
         "rest_framework.renderers.JSONRenderer",

--- a/stockpot/urls.py
+++ b/stockpot/urls.py
@@ -1,7 +1,7 @@
 from django.contrib import admin
 from django.urls import path, include
 from users.views import LoginPageView, ProfilePageView, RegisterPageView
-from pantry.views import PantryPageView
+from pantry.views import PantryPageView, RecipeSuggestionsPageView
 
 urlpatterns = [
     path("admin/", admin.site.urls),
@@ -12,4 +12,5 @@ urlpatterns = [
     path("login/", LoginPageView.as_view(), name="login-page"),
     path("profile/", ProfilePageView.as_view(), name="profile-page"),
     path("pantry/", PantryPageView.as_view(), name="pantry-page"),
+    path("recipes/", RecipeSuggestionsPageView.as_view(), name="recipes-page"),
 ]

--- a/templates/base.html
+++ b/templates/base.html
@@ -20,7 +20,7 @@
   <div class="collapse navbar-collapse" id="navbarNav">
     <ul class="navbar-nav ms-auto">
       <li class="nav-item"><a class="nav-link" href="/pantry/">My Stock</a></li>
-      <li class="nav-item"><a class="nav-link" href="#">Recipes</a></li>
+      <li class="nav-item"><a class="nav-link" href="/recipes/">Recipes</a></li>
       <li class="nav-item"><a class="nav-link" href="/profile/">Profile</a></li>
       <li class="nav-item"><a class="nav-link" href="#" id="logout-link">Log out</a></li>
     </ul>


### PR DESCRIPTION
## Summary

This PR implements the recipe suggestion feature (#25) and integrates the Spoonacular API with our digital pantry data.

## Type of change

- [ ] Bug fix
- [x] New feature
- [ ]️ Refactor (no functional change)
- [ ] Tests only
- [ ] Documentation
- [ ] Configuration / DevOps

## Related issue(s)

Closes #25 

## Changes made

- Created `pantry/services.py` to encapsulate all Spoonacular calls within the application
- New endpoint `/api/recipes/match/` for querying recipes
- New frontend page RecipeSuggestionsPageView

## Testing

- [x] I have added or updated tests to cover my changes
- [x] All new and existing tests pass locally (`python manage.py test pantry`)
- [x] Test coverage has not dropped below 80 %

## Notes for reviewers

As the Recipe details view is still not done, temporarily the recipe cards link to Spoonacular recipe details
