### PR TITLE
Fr10/dietary preferences

### DIFF
--- a/pantry/services.py
+++ b/pantry/services.py
@@ -6,6 +6,17 @@ SPOONACULAR_BASE_URL = "https://api.spoonacular.com"
 TIMEOUT = 10
 # Nutrients surfaced on the recipe detail page.
 KEY_NUTRIENTS = {"Calories", "Fat", "Carbohydrates", "Protein", "Fiber", "Sugar", "Sodium"}
+# Maps UserProfile dietary_preference keys to Spoonacular API parameters.
+SPOONACULAR_DIET_MAP = {
+    "vegetarian": "vegetarian",
+    "vegan": "vegan",
+    "keto": "ketogenic",
+}
+SPOONACULAR_INTOLERANCE_MAP = {
+    "gluten_free": "gluten",
+    "dairy_free": "dairy",
+    "nut_free": "tree nut,peanut",
+}
 
 
 class SpoonacularError(Exception):
@@ -17,13 +28,47 @@ class SpoonacularError(Exception):
         self.status_code = status_code
 
 
-def find_recipes_by_ingredients(ingredient_names: list[str], number: int = 12) -> list[dict]:
+def _build_diet_params(diets: list[str]) -> dict:
     """
-    Request to Spoonacular /recipes/findByIngredients endpoint.
+    Convert a list of UserProfile dietary preference keys into Spoonacular
+    request parameters for the complexSearch endpoint.
+
+    Returns a dict with zero or more of: {"diet": "...", "intolerances": "..."}.
+    """
+    diet_values = sorted({
+        SPOONACULAR_DIET_MAP[d]
+        for d in diets if d in SPOONACULAR_DIET_MAP
+    })
+    intolerance_values = sorted({
+        v.strip()
+        for d in diets if d in SPOONACULAR_INTOLERANCE_MAP
+        for v in SPOONACULAR_INTOLERANCE_MAP[d].split(",")
+    })
+    params = {}
+    if diet_values:
+        params["diet"] = ",".join(diet_values)
+    if intolerance_values:
+        params["intolerances"] = ",".join(intolerance_values)
+    return params
+
+
+def find_recipes_by_ingredients(
+    ingredient_names: list[str],
+    number: int = 12,
+    diets: list[str] | None = None,
+) -> list[dict]:
+    """
+    Request to Spoonacular API for recipes suggested by the provided ingredient names and optional dietary filters.
+
+    When `diets` is empty or None, uses Spoonacular /recipes/findByIngredients.
+    When `diets` is provided, switches to /recipes/complexSearch with
+    `fillIngredients=true` so the same used/missed ingredient counts are returned.
 
     Args:
-        ingredient_names    - List of ingredient name strings from the user's pantry.
-        number              - Maximum number of recipes to return (defaults to 12).
+        ingredient_names  - List of ingredient name strings from the user's pantry.
+        number            - Maximum number of recipes to return (defaults to 12).
+        diets             - Optional list of UserProfile dietary preference keys
+                            (e.g. ["vegan", "gluten_free"]).
 
     Returns a list of recipe dicts, each containing:
             id, title, image, used_count, missed_count,
@@ -36,18 +81,30 @@ def find_recipes_by_ingredients(ingredient_names: list[str], number: int = 12) -
     if not api_key:
         raise SpoonacularError("Spoonacular API key is not configured. Set SPOONACULAR_API_KEY in your environment.")
 
+    use_complex_search = bool(diets)
+
+    if use_complex_search:
+        url = f"{SPOONACULAR_BASE_URL}/recipes/complexSearch"
+        params = {
+            "includeIngredients": ",".join(ingredient_names),
+            "fillIngredients": True,
+            "number": number,
+            "ranking": 1,       # Spoonacular option to maximise used ingredients
+            "apiKey": api_key,
+            **_build_diet_params(diets),
+        }
+    else:
+        url = f"{SPOONACULAR_BASE_URL}/recipes/findByIngredients"
+        params = {
+            "ingredients": ",".join(ingredient_names),
+            "number": number,
+            "ranking": 1,       # Spoonacular option to maximise used ingredients
+            "ignorePantry": True,
+            "apiKey": api_key,
+        }
+
     try:
-        response = requests.get(
-            f"{SPOONACULAR_BASE_URL}/recipes/findByIngredients",
-            params={
-                "ingredients": ",".join(ingredient_names),
-                "number": number,
-                "ranking": 1,       # Spoonacular option to maximise used ingredients
-                "ignorePantry": True,
-                "apiKey": api_key,
-            },
-            timeout=TIMEOUT,
-        )
+        response = requests.get(url, params=params, timeout=TIMEOUT)
     except requests.exceptions.Timeout:
         raise SpoonacularError("The recipe service timed out. Please try again.")
     except requests.exceptions.RequestException as e:
@@ -63,6 +120,8 @@ def find_recipes_by_ingredients(ingredient_names: list[str], number: int = 12) -
         )
 
     raw = response.json()
+    # complexSearch wraps results, findByIngredients returns a bare list.
+    items = raw.get("results", raw) if isinstance(raw, dict) else raw
 
     return [
         {
@@ -74,7 +133,7 @@ def find_recipes_by_ingredients(ingredient_names: list[str], number: int = 12) -
             "used_ingredients": [i["name"] for i in item.get("usedIngredients", [])],
             "missed_ingredients": [i["name"] for i in item.get("missedIngredients", [])],
         }
-        for item in raw
+        for item in items
     ]
 
 

--- a/pantry/templates/pantry/recipes.html
+++ b/pantry/templates/pantry/recipes.html
@@ -64,6 +64,7 @@
 {% block extra_js %}
 <script>
   const MATCH_URL      = '/api/recipes/match/';
+  const DETAILS_URL    = '/recipes/';
   const PROFILE_URL    = '/api/auth/profile/';
   const FAVOURITES_URL = '/api/favourites/';
 
@@ -146,7 +147,7 @@
     empty.classList.add('d-none');
 
     recipes.forEach(r => {
-      const detailUrl      = `/recipes/${r.id}/`;
+      const detailUrl      = `${DETAILS_URL}${r.id}/`;
       const isSaved        = savedIds.has(r.id);
       const favouriteLabel = isSaved ? '\u2665 Saved' : '\u2661 Save';
       const favouriteClass = isSaved ? 'btn-warning' : 'btn-outline-warning';

--- a/pantry/templates/pantry/recipes.html
+++ b/pantry/templates/pantry/recipes.html
@@ -5,9 +5,41 @@
 {% block content %}
 <div class="container py-4">
 
-  <div class="d-flex justify-content-between align-items-center mb-4">
+  <div class="d-flex justify-content-between align-items-center mb-3">
     <h4 class="fw-bold mb-0">Recipe Suggestions</h4>
-    <button class="btn btn-primary" id="btn-find-recipes">Find Recipes</button>
+    <div class="d-flex gap-2">
+      <button class="btn btn-outline-secondary btn-sm" type="button"
+              data-bs-toggle="collapse" data-bs-target="#filter-panel" aria-expanded="false">
+        &#9881; Dietary Filters
+      </button>
+      <button class="btn btn-primary" id="btn-find-recipes">Find Recipes</button>
+    </div>
+  </div>
+
+  <!-- Dietary filter panel -->
+  <div class="collapse mb-3" id="filter-panel">
+    <div class="card card-body">
+      <p class="small text-muted mb-2">
+        Select dietary filters to restrict your recipe suggestions. Filters are pre-filled from your
+        <a href="/profile/">Profile</a> settings.
+      </p>
+      <div class="row g-2" id="diet-checkboxes">
+        {% for key, label in dietary_choices %}
+        <div class="col-6 col-md-4 col-lg-3">
+          <div class="form-check">
+            <input class="form-check-input diet-filter" type="checkbox"
+                   id="diet-{{ key }}" value="{{ key }}">
+            <label class="form-check-label" for="diet-{{ key }}">{{ label }}</label>
+          </div>
+        </div>
+        {% endfor %}
+      </div>
+      <div class="mt-2">
+        <button class="btn btn-sm btn-link p-0 text-muted" id="btn-clear-filters">
+          Clear all filters
+        </button>
+      </div>
+    </div>
   </div>
 
   <div id="alert-area"></div>
@@ -22,8 +54,8 @@
   <div class="row g-4" id="recipe-grid"></div>
 
   <div id="empty-state" class="text-center text-muted py-5 d-none">
-    <p class="mb-1">No recipes found for your current pantry.</p>
-    <p class="small">Try adding more ingredients to get better suggestions.</p>
+    <p class="mb-1">No recipes found for your current pantry and filters.</p>
+    <p class="small">Try adjusting your dietary filters or adding more ingredients.</p>
   </div>
 
 </div>
@@ -32,10 +64,27 @@
 {% block extra_js %}
 <script>
   const MATCH_URL      = '/api/recipes/match/';
-  const DETAILS_URL    = '/recipes/';
+  const PROFILE_URL    = '/api/auth/profile/';
   const FAVOURITES_URL = '/api/favourites/';
 
   let savedIds = new Set();
+
+  // Pre-populate checkboxes from the user's saved dietary preferences.
+  async function loadProfileFilters() {
+    try {
+      const resp = await fetch(PROFILE_URL, { credentials: 'same-origin' });
+      if (!resp.ok) return;
+      const data = await resp.json();
+      (data.dietary_preferences || []).forEach(key => {
+        const cb = document.getElementById(`diet-${key}`);
+        if (cb) cb.checked = true;
+      });
+    } catch { /* non-critical */ }
+  }
+
+  function getSelectedDiets() {
+    return Array.from(document.querySelectorAll('.diet-filter:checked')).map(cb => cb.value);
+  }
 
   async function loadFavouriteIds() {
     try {
@@ -43,7 +92,7 @@
       if (!resp.ok) return;
       const data = await resp.json();
       (data.results ?? data).forEach(f => savedIds.add(f.recipe_id));
-    } catch { /* TODO: Handle this case */ }
+    } catch { /* non-critical */ }
   }
 
   async function toggleFavourite(r, btn) {
@@ -90,28 +139,24 @@
   }
 
   function renderRecipes(recipes) {
-    const grid = document.getElementById('recipe-grid');
+    const grid  = document.getElementById('recipe-grid');
     const empty = document.getElementById('empty-state');
     grid.innerHTML = '';
-
-    if (!recipes.length) {
-      empty.classList.remove('d-none');
-      return;
-    }
+    if (!recipes.length) { empty.classList.remove('d-none'); return; }
     empty.classList.add('d-none');
 
     recipes.forEach(r => {
-      const detailUrl = `${DETAILS_URL}${r.id}/`;
-      const isSaved = savedIds.has(r.id);
+      const detailUrl      = `/recipes/${r.id}/`;
+      const isSaved        = savedIds.has(r.id);
       const favouriteLabel = isSaved ? '\u2665 Saved' : '\u2661 Save';
       const favouriteClass = isSaved ? 'btn-warning' : 'btn-outline-warning';
-      const usedBadge = `<span class="badge bg-success me-1">${r.used_count} in pantry</span>`;
-      const missBadge = r.missed_count ? `<span class="badge bg-secondary">${r.missed_count} missing</span>` : '';
-      const usedList  = r.used_ingredients.length
+      const usedBadge      = `<span class="badge bg-success me-1">${r.used_count} in pantry</span>`;
+      const missBadge      = r.missed_count ? `<span class="badge bg-secondary">${r.missed_count} missing</span>` : '';
+      const usedList       = r.used_ingredients.length
         ? `<p class="small text-muted mb-1"><strong>Have:</strong> ${r.used_ingredients.join(', ')}</p>` : '';
-      const missList  = r.missed_ingredients.length
+      const missList       = r.missed_ingredients.length
         ? `<p class="small text-muted mb-0"><strong>Missing:</strong> ${r.missed_ingredients.join(', ')}</p>` : '';
-      const imgHtml   = r.image
+      const imgHtml        = r.image
         ? `<img src="${r.image}" class="card-img-top" alt="${r.title}" style="height:180px;object-fit:cover;">`
         : `<div class="bg-light d-flex align-items-center justify-content-center" style="height:180px;"><span class="text-muted">No image</span></div>`;
 
@@ -142,8 +187,14 @@
     setLoading(true);
     document.getElementById('recipe-grid').innerHTML = '';
     document.getElementById('empty-state').classList.add('d-none');
+
+    const selectedDiets = getSelectedDiets();
+    const url = selectedDiets.length
+      ? `${MATCH_URL}?diets=${encodeURIComponent(selectedDiets.join(','))}`
+      : MATCH_URL;
+
     try {
-      const resp = await fetch(MATCH_URL, { credentials: 'same-origin' });
+      const resp = await fetch(url, { credentials: 'same-origin' });
       const data = await resp.json();
       if (!resp.ok) {
         showAlert(data.detail || 'An error occurred while fetching recipes.', resp.status === 429 ? 'warning' : 'danger');
@@ -158,6 +209,10 @@
     }
   });
 
+  document.getElementById('btn-clear-filters').addEventListener('click', () => {
+    document.querySelectorAll('.diet-filter').forEach(cb => cb.checked = false);
+  });
+
   document.getElementById('logout-link').addEventListener('click', e => {
     e.preventDefault();
     fetch('/api/auth/logout/', {
@@ -167,5 +222,6 @@
   });
 
   loadFavouriteIds();
+  loadProfileFilters();
 </script>
 {% endblock %}

--- a/pantry/tests/test_services.py
+++ b/pantry/tests/test_services.py
@@ -2,7 +2,12 @@ from unittest.mock import patch
 
 import requests
 from django.test import TestCase, override_settings
-from pantry.services import SpoonacularError, find_recipes_by_ingredients, get_recipe_details
+from pantry.services import (
+    SpoonacularError,
+    _build_diet_params,
+    find_recipes_by_ingredients,
+    get_recipe_details,
+)
 
 
 class RecipeSuggestionsServiceTest(TestCase):
@@ -123,6 +128,122 @@ class RecipeSuggestionsServiceTest(TestCase):
         result = find_recipes_by_ingredients(["Flour"])
 
         self.assertEqual(result[0]["image"], "")
+
+
+class RecipeDietaryFilteringServiceTest(TestCase):
+
+    def test_empty_diets_returns_empty_params(self):
+        self.assertEqual(_build_diet_params([]), {})
+
+    def test_vegetarian_maps_to_diet_param(self):
+        result = _build_diet_params(["vegetarian"])
+        self.assertEqual(result, {"diet": "vegetarian"})
+
+    def test_vegan_maps_to_diet_param(self):
+        result = _build_diet_params(["vegan"])
+        self.assertEqual(result, {"diet": "vegan"})
+
+    def test_keto_maps_to_ketogenic(self):
+        result = _build_diet_params(["keto"])
+        self.assertEqual(result, {"diet": "ketogenic"})
+
+    def test_gluten_free_maps_to_intolerance(self):
+        result = _build_diet_params(["gluten_free"])
+        self.assertEqual(result, {"intolerances": "gluten"})
+
+    def test_dairy_free_maps_to_intolerance(self):
+        result = _build_diet_params(["dairy_free"])
+        self.assertEqual(result, {"intolerances": "dairy"})
+
+    def test_nut_free_maps_to_two_intolerances(self):
+        result = _build_diet_params(["nut_free"])
+        intolerances = sorted(result["intolerances"].split(","))
+        self.assertIn("peanut", intolerances)
+        self.assertIn("tree nut", intolerances)
+
+    def test_unknown_key_is_ignored(self):
+        self.assertEqual(_build_diet_params(["non-existant"]), {})
+
+    def test_mixed_diet_and_intolerance(self):
+        result = _build_diet_params(["vegan", "gluten_free"])
+        self.assertEqual(result["diet"], "vegan")
+        self.assertEqual(result["intolerances"], "gluten")
+
+    @override_settings(SPOONACULAR_API_KEY="test-key")
+    @patch("pantry.services.requests.get")
+    def test_uses_complex_search_endpoint_when_diets_provided(self, mock_get):
+        mock_get.return_value.ok = True
+        mock_get.return_value.status_code = 200
+        mock_get.return_value.json.return_value = {"results": []}
+
+        find_recipes_by_ingredients(["Flour"], diets=["vegan"])
+
+        called_url = mock_get.call_args.args[0]
+        self.assertIn("complexSearch", called_url)
+
+    @override_settings(SPOONACULAR_API_KEY="test-key")
+    @patch("pantry.services.requests.get")
+    def test_uses_find_by_ingredients_endpoint_when_no_diets(self, mock_get):
+        mock_get.return_value.ok = True
+        mock_get.return_value.status_code = 200
+        mock_get.return_value.json.return_value = []
+
+        find_recipes_by_ingredients(["Flour"])
+
+        called_url = mock_get.call_args.args[0]
+        self.assertIn("findByIngredients", called_url)
+
+    @override_settings(SPOONACULAR_API_KEY="test-key")
+    @patch("pantry.services.requests.get")
+    def test_complex_search_response_is_unwrapped(self, mock_get):
+        api_response = {
+            "results": [
+                {
+                    "id": 10,
+                    "title": "Vegan Pasta",
+                    "image": "https://example.com/pasta.jpg",
+                    "usedIngredientCount": 3,
+                    "missedIngredientCount": 0,
+                    "usedIngredients": [{"name": "Pasta"}, {"name": "Tomato"}, {"name": "Basil"}],
+                    "missedIngredients": [],
+                }
+            ]
+        }
+        mock_get.return_value.ok = True
+        mock_get.return_value.status_code = 200
+        mock_get.return_value.json.return_value = api_response
+
+        result = find_recipes_by_ingredients(["Pasta"], diets=["vegan"])
+
+        self.assertEqual(len(result), 1)
+        self.assertEqual(result[0]["id"], 10)
+        self.assertEqual(result[0]["title"], "Vegan Pasta")
+
+    @override_settings(SPOONACULAR_API_KEY="test-key")
+    @patch("pantry.services.requests.get")
+    def test_diet_params_are_passed_to_complex_search(self, mock_get):
+        mock_get.return_value.ok = True
+        mock_get.return_value.status_code = 200
+        mock_get.return_value.json.return_value = {"results": []}
+
+        find_recipes_by_ingredients(["Flour"], diets=["vegan", "gluten_free"])
+
+        sent_params = mock_get.call_args.kwargs["params"]
+        self.assertEqual(sent_params["diet"], "vegan")
+        self.assertIn("gluten", sent_params["intolerances"])
+
+    @override_settings(SPOONACULAR_API_KEY="test-key")
+    @patch("pantry.services.requests.get")
+    def test_halal_kosher_do_not_add_extra_params(self, mock_get):
+        mock_get.return_value.ok = True
+        mock_get.return_value.status_code = 200
+        mock_get.return_value.json.return_value = {"results": []}
+
+        find_recipes_by_ingredients(["Flour"], diets=["halal", "kosher"])
+
+        sent_params = mock_get.call_args.kwargs["params"]
+        self.assertNotIn("diet", sent_params)
+        self.assertNotIn("intolerances", sent_params)
 
 
 class RecipeDetailServiceTest(TestCase):

--- a/pantry/tests/test_views.py
+++ b/pantry/tests/test_views.py
@@ -429,6 +429,38 @@ class RecipeMatchViewTest(APITestCase):
         self.assertEqual(response.status_code, status.HTTP_200_OK)
         self.assertEqual(response.data, [])
 
+    @patch("pantry.views.find_recipes_by_ingredients")
+    def test_diets_query_param_pass_to_service(self, mock_service):
+        mock_service.return_value = [self.expected_recipe]
+        StockItem.objects.create(user=self.user, ingredient=self.flour, quantity=500)
+
+        response = self.client.get(self.url, {"diets": "vegan,gluten_free"})
+
+        self.assertEqual(response.status_code, status.HTTP_200_OK)
+        _, kwargs = mock_service.call_args
+        self.assertIn("vegan", kwargs["diets"])
+        self.assertIn("gluten_free", kwargs["diets"])
+
+    @patch("pantry.views.find_recipes_by_ingredients")
+    def test_when_diets_param_absent_passes_none(self, mock_service):
+        mock_service.return_value = []
+        StockItem.objects.create(user=self.user, ingredient=self.flour, quantity=500)
+
+        self.client.get(self.url)
+
+        _, kwargs = mock_service.call_args
+        self.assertIsNone(kwargs["diets"])
+
+    @patch("pantry.views.find_recipes_by_ingredients")
+    def test_when_diets_param_is_empty_string_passes_none(self, mock_service):
+        mock_service.return_value = []
+        StockItem.objects.create(user=self.user, ingredient=self.flour, quantity=500)
+
+        self.client.get(self.url, {"diets": ""})
+
+        _, kwargs = mock_service.call_args
+        self.assertIsNone(kwargs["diets"])
+
 
 class RecipeSuggestionsPageViewTest(TestCase):
 
@@ -441,6 +473,12 @@ class RecipeSuggestionsPageViewTest(TestCase):
         response = self.client.get(self.url)
         self.assertEqual(response.status_code, 200)
         self.assertTemplateUsed(response, "pantry/recipes.html")
+
+    def test_context_includes_dietary_choices(self):
+        self.client.force_login(self.user)
+        response = self.client.get(self.url)
+        self.assertIn("dietary_choices", response.context)
+        self.assertGreater(len(response.context["dietary_choices"]), 0)
 
 
 class PantryPageViewTest(TestCase):

--- a/pantry/views.py
+++ b/pantry/views.py
@@ -82,6 +82,10 @@ class RecipeMatchView(APIView):
     permission_classes = [IsAuthenticated]
 
     def get(self, request):
+        # Parse optional comma-separated dietary filter param: ?diets=vegan,gluten_free
+        diets_param = request.query_params.get("diets", "").strip()
+        diets = [d.strip() for d in diets_param.split(",") if d.strip()] or None
+
         ingredient_names = list(
             StockItem.objects.filter(user=request.user)
             .select_related("ingredient")
@@ -95,7 +99,7 @@ class RecipeMatchView(APIView):
             )
 
         try:
-            recipes = find_recipes_by_ingredients(ingredient_names)
+            recipes = find_recipes_by_ingredients(ingredient_names, diets=diets)
         except SpoonacularError as e:
             http_status = status.HTTP_503_SERVICE_UNAVAILABLE
             if e.status_code == 402:
@@ -111,6 +115,13 @@ class RecipeSuggestionsPageView(TemplateView):
     Recipe suggestions HTML page.
     """
     template_name = "pantry/recipes.html"
+
+    # TODO: This type of implementation could help to simplify JS in other views
+    def get_context_data(self, **kwargs):
+        from users.models import DIETARY_CHOICES
+        context = super().get_context_data(**kwargs)
+        context["dietary_choices"] = DIETARY_CHOICES
+        return context
 
 
 class RecipeDetailView(APIView):

--- a/users/models.py
+++ b/users/models.py
@@ -9,8 +9,6 @@ DIETARY_CHOICES = [
     ("gluten_free", "Gluten Free"),
     ("dairy_free", "Dairy Free"),
     ("nut_free", "Nut Free"),
-    ("halal", "Halal"),
-    ("kosher", "Kosher"),
     ("keto", "Keto"),
 ]
 

--- a/users/templates/users/register.html
+++ b/users/templates/users/register.html
@@ -97,6 +97,9 @@
       if (response.ok) {
         form.classList.add('d-none');
         showAlert(`Account created for ${data.email}. You can now log in.`, 'success');
+        setTimeout(function() {
+            window.location.href = '/login/';
+        }, 3500);
       } else {
         const fieldNames = ['email', 'password', 'password2'];
         let hasFieldError = false;


### PR DESCRIPTION
## Summary

This PR implements the dietary preference settings (#28), allowing users to refine their recipe suggestions based on specific dietary requirements such as Vegan, Vegetarian, or Gluten-Free.

As it was deemed a small change, #31 was addressed too.

## Type of change

- [ ] Bug fix
- [x] New feature
- [ ]  Refactor (no functional change)
- [ ] Tests only
- [ ] Documentation
- [ ] Configuration / DevOps

## Related issue(s)

Closes #28 
Closes #31 

## Changes made

- Modified `pantry/services.py` to accept dietary preferences.
- Integrated `complexSearch` Spoonacular endpoint.
- Integrated dietary preferences into HTML views and API endpoints.
- 

## Testing

- [x] I have added or updated tests to cover my changes
- [x] All new and existing tests pass locally (`python manage.py test pantry`)
- [x] Test coverage has not dropped below 80 %

## Notes for reviewers

For #31 the redirect was done to `login` instead of `My Stock` as the registration process doesn't authenticate the user.