### PR TITLE
Feature/59 unit separation

### DIFF
--- a/pantry/admin.py
+++ b/pantry/admin.py
@@ -4,14 +4,14 @@ from .models import Ingredient, StockItem
 
 @admin.register(Ingredient)
 class IngredientAdmin(admin.ModelAdmin):
-    list_display = ["name", "unit"]
+    list_display = ["name"]
     search_fields = ["name"]
     ordering = ["name"]
 
 
 @admin.register(StockItem)
 class StockItemAdmin(admin.ModelAdmin):
-    list_display = ["user", "ingredient", "quantity", "expiry_date", "updated_at"]
-    list_filter = ["ingredient__unit", "expiry_date"]
+    list_display = ["user", "ingredient", "unit", "quantity", "expiry_date", "updated_at"]
+    list_filter = ["unit", "expiry_date"]
     search_fields = ["user__username", "ingredient__name"]
     ordering = ["user", "ingredient__name"]

--- a/pantry/migrations/0003_move_unit_to_stockitem.py
+++ b/pantry/migrations/0003_move_unit_to_stockitem.py
@@ -1,0 +1,72 @@
+"""
+Manual migration to move the `unit` field from Ingredient to StockItem.
+
+- Adds `unit` field to StockItem (populated from the Ingredient's existing unit).
+- Removes `unit` field from Ingredient.
+"""
+
+from django.db import migrations, models
+
+
+def copy_units_from_ingredient(apps, schema_editor):
+    """Copies Ingredient.unit into StockItem.unit before the field is removed."""
+    StockItem = apps.get_model("pantry", "StockItem")
+    for stock in StockItem.objects.select_related("ingredient").all():
+        stock.unit = stock.ingredient.unit
+        stock.save(update_fields=["unit"])
+
+
+class Migration(migrations.Migration):
+
+    dependencies = [
+        ("pantry", "0002_savedrecipe"),
+    ]
+
+    operations = [
+        # Unit field in StockItem as nullable so the data migration can run first
+        migrations.AddField(
+            model_name="stockitem",
+            name="unit",
+            field=models.CharField(
+                blank=True,
+                max_length=10,
+                choices=[
+                    ("g", "Grams"),
+                    ("kg", "Kilograms"),
+                    ("ml", "Millilitres"),
+                    ("L", "Litres"),
+                    ("pcs", "Pieces"),
+                    ("tbsp", "Tablespoons"),
+                    ("tsp", "Teaspoons"),
+                    ("cup", "Cups"),
+                ],
+                default="",
+            ),
+        ),
+        # Copy the unit value from each StockItem's Ingredient
+        migrations.RunPython(copy_units_from_ingredient, migrations.RunPython.noop),
+        # After migrating the values, the field can be made non-blank
+        migrations.AlterField(
+            model_name="stockitem",
+            name="unit",
+            field=models.CharField(
+                max_length=10,
+                choices=[
+                    ("g", "Grams"),
+                    ("kg", "Kilograms"),
+                    ("ml", "Millilitres"),
+                    ("L", "Litres"),
+                    ("pcs", "Pieces"),
+                    ("tbsp", "Tablespoons"),
+                    ("tsp", "Teaspoons"),
+                    ("cup", "Cups"),
+                ],
+                default="g",
+            ),
+        ),
+        # Remove unit from Ingredient after it's been copied to StockItem
+        migrations.RemoveField(
+            model_name="ingredient",
+            name="unit",
+        ),
+    ]

--- a/pantry/models.py
+++ b/pantry/models.py
@@ -3,6 +3,16 @@ from django.contrib.auth.models import User
 
 
 class Ingredient(models.Model):
+    name = models.CharField(max_length=200, unique=True)
+
+    class Meta:
+        ordering = ["name"]
+
+    def __str__(self):
+        return self.name
+
+
+class StockItem(models.Model):
     class Unit(models.TextChoices):
         GRAMS = "g", "Grams"
         KILOGRAMS = "kg", "Kilograms"
@@ -13,19 +23,9 @@ class Ingredient(models.Model):
         TEASPOONS = "tsp", "Teaspoons"
         CUPS = "cup", "Cups"
 
-    name = models.CharField(max_length=200, unique=True)
-    unit = models.CharField(max_length=10, choices=Unit.choices, default=Unit.GRAMS)
-
-    class Meta:
-        ordering = ["name"]
-
-    def __str__(self):
-        return f"{self.name} ({self.unit})"
-
-
-class StockItem(models.Model):
     user = models.ForeignKey(User, on_delete=models.CASCADE, related_name="stock_items")
     ingredient = models.ForeignKey(Ingredient, on_delete=models.CASCADE, related_name="stock_items")
+    unit = models.CharField(max_length=10, choices=Unit.choices, default=Unit.GRAMS)
     quantity = models.DecimalField(max_digits=10, decimal_places=2)
     expiry_date = models.DateField(null=True, blank=True)
     created_at = models.DateTimeField(auto_now_add=True)
@@ -36,7 +36,7 @@ class StockItem(models.Model):
         ordering = ["ingredient__name"]
 
     def __str__(self):
-        return f"{self.user.username} – {self.ingredient.name}: {self.quantity}{self.ingredient.unit}"
+        return f"{self.user.username} – {self.ingredient.name}: {self.quantity}{self.unit}"
 
 
 class SavedRecipe(models.Model):

--- a/pantry/serializers.py
+++ b/pantry/serializers.py
@@ -30,25 +30,6 @@ class StockItemWriteSerializer(serializers.ModelSerializer):
         request = self.context.get("request")
         ingredient = attrs.get("ingredient")
 
-        # On create, prevent duplicates. the User should use PATCH to update the existing item instead
-        if self.instance is None and ingredient:
-            if StockItem.objects.filter(user=request.user, ingredient=ingredient).exists():
-                raise serializers.ValidationError(
-                    {"ingredient_id": "This ingredient is already in your pantry. Use PATCH to update it."}
-                )
-        return attrs
-
-    def create(self, validated_data):
-        validated_data["user"] = self.context["request"].user
-        return super().create(validated_data)
-
-    def to_representation(self, instance):
-        return StockItemReadSerializer(instance, context=self.context).data
-
-    def validate(self, attrs):
-        request = self.context.get("request")
-        ingredient = attrs.get("ingredient")
-
         # On create, prevent duplicates. The User should use PATCH to update the existing item instead
         if self.instance is None and ingredient:
             if StockItem.objects.filter(user=request.user, ingredient=ingredient).exists():

--- a/pantry/serializers.py
+++ b/pantry/serializers.py
@@ -5,7 +5,7 @@ from .models import Ingredient, SavedRecipe, StockItem
 class IngredientSerializer(serializers.ModelSerializer):
     class Meta:
         model = Ingredient
-        fields = ["id", "name", "unit"]
+        fields = ["id", "name"]
 
 
 class StockItemReadSerializer(serializers.ModelSerializer):
@@ -13,7 +13,7 @@ class StockItemReadSerializer(serializers.ModelSerializer):
 
     class Meta:
         model = StockItem
-        fields = ["id", "ingredient", "quantity", "expiry_date", "created_at", "updated_at"]
+        fields = ["id", "ingredient", "unit", "quantity", "expiry_date", "created_at", "updated_at"]
 
 
 class StockItemWriteSerializer(serializers.ModelSerializer):
@@ -24,7 +24,26 @@ class StockItemWriteSerializer(serializers.ModelSerializer):
 
     class Meta:
         model = StockItem
-        fields = ["id", "ingredient_id", "quantity", "expiry_date"]
+        fields = ["id", "ingredient_id", "unit", "quantity", "expiry_date"]
+
+    def validate(self, attrs):
+        request = self.context.get("request")
+        ingredient = attrs.get("ingredient")
+
+        # On create, prevent duplicates. the User should use PATCH to update the existing item instead
+        if self.instance is None and ingredient:
+            if StockItem.objects.filter(user=request.user, ingredient=ingredient).exists():
+                raise serializers.ValidationError(
+                    {"ingredient_id": "This ingredient is already in your pantry. Use PATCH to update it."}
+                )
+        return attrs
+
+    def create(self, validated_data):
+        validated_data["user"] = self.context["request"].user
+        return super().create(validated_data)
+
+    def to_representation(self, instance):
+        return StockItemReadSerializer(instance, context=self.context).data
 
     def validate(self, attrs):
         request = self.context.get("request")

--- a/pantry/templates/pantry/stock.html
+++ b/pantry/templates/pantry/stock.html
@@ -198,7 +198,7 @@
           <td>${statusBadge(item.expiry_date)}</td>
           <td>${item.ingredient.name}</td>
           <td>${item.quantity}</td>
-          <td>${item.ingredient.unit}</td>
+          <td>${item.unit}</td>
           <td>${formatDate(item.expiry_date)}</td>
           <td>
             <button class="btn btn-outline-secondary btn-sm me-1" onclick="openEdit(${item.id})">Edit</button>
@@ -257,14 +257,10 @@
     const a = document.createElement('button');
     a.type = 'button';
     a.className = 'list-group-item list-group-item-action';
-    a.textContent = `${ing.name} (${ing.unit})`;
+    a.textContent = ing.name;
     a.addEventListener('click', () => {
       document.getElementById('ingredient-id').value = ing.id;
       searchInput.value = ing.name;
-      // Lock unit to the existing ingredient's unit
-      const unitSelect = document.getElementById('item-unit');
-      unitSelect.value = ing.unit;
-      unitSelect.disabled = true;
       suggestionsBox.innerHTML = '';
       ingredientHint.textContent = '';
     });
@@ -277,21 +273,12 @@
     }
   });
 
-  // Re-enable unit when user clears the ingredient field
-  searchInput.addEventListener('change', () => {
-    if (!document.getElementById('ingredient-id').value) {
-      document.getElementById('item-unit').disabled = false;
-    }
-  });
-
   document.getElementById('btn-add-item').addEventListener('click', () => {
     document.getElementById('itemModalLabel').textContent = 'Add Item';
     document.getElementById('edit-id').value = '';
     document.getElementById('ingredient-search').value = '';
     document.getElementById('ingredient-id').value = '';
-    const unitSelect = document.getElementById('item-unit');
-    unitSelect.value = '';
-    unitSelect.disabled = false;
+    document.getElementById('item-unit').value = '';
     document.getElementById('item-quantity').value = '';
     document.getElementById('item-expiry').value = '';
     ingredientHint.textContent = '';
@@ -305,9 +292,7 @@
     document.getElementById('edit-id').value = item.id;
     document.getElementById('ingredient-search').value = item.ingredient.name;
     document.getElementById('ingredient-id').value = item.ingredient.id;
-    const unitSelect = document.getElementById('item-unit');
-    unitSelect.value = item.ingredient.unit;
-    unitSelect.disabled = true;   // unit is fixed to the existing ingredient
+    document.getElementById('item-unit').value = item.unit;
     document.getElementById('item-quantity').value = item.quantity;
     document.getElementById('item-expiry').value = item.expiry_date || '';
     ingredientHint.textContent = '';
@@ -319,29 +304,28 @@
     e.preventDefault();
     hideModalAlert();
 
-    const editId      = document.getElementById('edit-id').value;
+    const editId       = document.getElementById('edit-id').value;
     let   ingredientId = document.getElementById('ingredient-id').value;
-    const name        = document.getElementById('ingredient-search').value.trim();
-    const unit        = document.getElementById('item-unit').value;
-    const quantity    = document.getElementById('item-quantity').value;
-    const expiryDate  = document.getElementById('item-expiry').value;
+    const name         = document.getElementById('ingredient-search').value.trim();
+    const unit         = document.getElementById('item-unit').value;
+    const quantity     = document.getElementById('item-quantity').value;
+    const expiryDate   = document.getElementById('item-expiry').value;
 
     if (!name)     { showModalAlert('Please enter an ingredient name.'); return; }
     if (!unit)     { showModalAlert('Please select a unit.'); return; }
     if (!quantity) { showModalAlert('Please enter a quantity.'); return; }
     if (parseFloat(quantity) <= 0) { showModalAlert('Quantity must be a positive number.'); return; }
 
-    // If no existing ingredient was selected, create or retrieve one by name+unit
+    // If no existing ingredient was selected, create one by name
     if (!ingredientId) {
       const ingResp = await fetch(INGREDIENTS_URL, {
         method: 'POST',
         credentials: 'same-origin',
         headers: { 'Content-Type': 'application/json', 'X-CSRFToken': getCsrf() },
-        body: JSON.stringify({ name, unit }),
+        body: JSON.stringify({ name }),
       });
       if (!ingResp.ok) {
         const err = await ingResp.json();
-        // If ingredient already exists with a different unit, surface the error
         showModalAlert(Object.values(err).flat().join(' '));
         return;
       }
@@ -349,7 +333,11 @@
       ingredientId = ing.id;
     }
 
-    const payload = { ingredient_id: parseInt(ingredientId), quantity: parseFloat(quantity) };
+    const payload = {
+      ingredient_id: parseInt(ingredientId),
+      unit,
+      quantity: parseFloat(quantity),
+    };
     if (expiryDate) payload.expiry_date = expiryDate;
 
     const url    = editId ? `${STOCK_URL}${editId}/` : STOCK_URL;

--- a/pantry/tests/test_models.py
+++ b/pantry/tests/test_models.py
@@ -9,39 +9,49 @@ from pantry.models import Ingredient, StockItem, SavedRecipe
 
 
 class IngredientModelTest(TestCase):
+
     def test_str_representation(self):
         ingredient = Ingredient(name="Flour")
         self.assertEqual(str(ingredient), "Flour")
 
     def test_name_is_unique(self):
-        Ingredient.objects.create(name="Flour", unit="g")
+        Ingredient.objects.create(name="Flour")
         with self.assertRaises(IntegrityError):
-            Ingredient.objects.create(name="Flour", unit="kg")
-
-    def test_all_unit_choices_are_valid(self):
-        valid_units = ["g", "kg", "ml", "L", "pcs", "tbsp", "tsp", "cup"]
-        for unit in valid_units:
-            ing = Ingredient.objects.create(name=f"Ingredient {unit}", unit=unit)
-            self.assertEqual(ing.unit, unit)
+            Ingredient.objects.create(name="Flour")
 
     def test_ordering_is_alphabetical_by_name(self):
-        Ingredient.objects.create(name="Zucchini", unit="pcs")
-        Ingredient.objects.create(name="Apple", unit="pcs")
-        Ingredient.objects.create(name="Milk", unit="L")
+        Ingredient.objects.create(name="Zucchini")
+        Ingredient.objects.create(name="Apple")
+        Ingredient.objects.create(name="Milk")
         names = list(Ingredient.objects.values_list("name", flat=True))
         self.assertEqual(names, ["Apple", "Milk", "Zucchini"])
 
 
 class StockItemModelTest(TestCase):
+
     def setUp(self):
         self.user = User.objects.create_user(username="testuser", password="pass")
-        self.ingredient = Ingredient.objects.create(name="Flour", unit="g")
+        self.ingredient = Ingredient.objects.create(name="Flour")
 
     def test_str_representation(self):
         stock = StockItem.objects.create(
-            user=self.user, ingredient=self.ingredient, quantity=500
+            user=self.user, ingredient=self.ingredient, quantity=500, unit="g"
         )
         self.assertEqual(str(stock), "testuser – Flour: 500g")
+
+    def test_default_unit_is_grams(self):
+        stock = StockItem.objects.create(
+            user=self.user, ingredient=self.ingredient, quantity=100
+        )
+        self.assertEqual(stock.unit, StockItem.Unit.GRAMS)
+
+    def test_all_unit_choices_are_valid(self):
+        valid_units = ["g", "kg", "ml", "L", "pcs", "tbsp", "tsp", "cup"]
+        ingredient2 = Ingredient.objects.create(name="Water")
+        for i, unit in enumerate(valid_units):
+            ing = Ingredient.objects.create(name=f"Ingredient {i}")
+            stock = StockItem.objects.create(user=self.user, ingredient=ing, quantity=1, unit=unit)
+            self.assertEqual(stock.unit, unit)
 
     def test_expiry_date_is_optional(self):
         stock = StockItem.objects.create(
@@ -70,13 +80,13 @@ class StockItemModelTest(TestCase):
                 user=self.user, ingredient=self.ingredient, quantity=200
             )
 
-    def test_different_users_can_stock_the_same_ingredient(self):
+    def test_different_users_can_stock_same_ingredient_with_different_units(self):
         user2 = User.objects.create_user(username="user2", password="pass")
-        StockItem.objects.create(user=self.user, ingredient=self.ingredient, quantity=100)
+        StockItem.objects.create(user=self.user, ingredient=self.ingredient, quantity=100, unit="g")
         stock2 = StockItem.objects.create(
-            user=user2, ingredient=self.ingredient, quantity=200
+            user=user2, ingredient=self.ingredient, quantity=2, unit="kg"
         )
-        self.assertEqual(stock2.quantity, 200)
+        self.assertEqual(stock2.unit, "kg")
 
     def test_deleting_user_cascades_to_stock_items(self):
         StockItem.objects.create(user=self.user, ingredient=self.ingredient, quantity=100)
@@ -89,13 +99,11 @@ class StockItemModelTest(TestCase):
         self.assertEqual(StockItem.objects.count(), 0)
 
     def test_ordering_is_alphabetical_by_ingredient_name(self):
-        apple = Ingredient.objects.create(name="Apple", unit="pcs")
+        apple = Ingredient.objects.create(name="Apple")
         StockItem.objects.create(user=self.user, ingredient=self.ingredient, quantity=100)
         StockItem.objects.create(user=self.user, ingredient=apple, quantity=5)
         names = list(
-            StockItem.objects.filter(user=self.user).values_list(
-                "ingredient__name", flat=True
-            )
+            StockItem.objects.filter(user=self.user).values_list("ingredient__name", flat=True)
         )
         self.assertEqual(names, ["Apple", "Flour"])
 

--- a/pantry/tests/test_models.py
+++ b/pantry/tests/test_models.py
@@ -10,12 +10,8 @@ from pantry.models import Ingredient, StockItem, SavedRecipe
 
 class IngredientModelTest(TestCase):
     def test_str_representation(self):
-        ingredient = Ingredient(name="Flour", unit="g")
-        self.assertEqual(str(ingredient), "Flour (g)")
-
-    def test_default_unit_is_grams(self):
-        ingredient = Ingredient.objects.create(name="Salt")
-        self.assertEqual(ingredient.unit, Ingredient.Unit.GRAMS)
+        ingredient = Ingredient(name="Flour")
+        self.assertEqual(str(ingredient), "Flour")
 
     def test_name_is_unique(self):
         Ingredient.objects.create(name="Flour", unit="g")

--- a/pantry/tests/test_models.py
+++ b/pantry/tests/test_models.py
@@ -47,7 +47,6 @@ class StockItemModelTest(TestCase):
 
     def test_all_unit_choices_are_valid(self):
         valid_units = ["g", "kg", "ml", "L", "pcs", "tbsp", "tsp", "cup"]
-        ingredient2 = Ingredient.objects.create(name="Water")
         for i, unit in enumerate(valid_units):
             ing = Ingredient.objects.create(name=f"Ingredient {i}")
             stock = StockItem.objects.create(user=self.user, ingredient=ing, quantity=1, unit=unit)

--- a/pantry/tests/test_serializers.py
+++ b/pantry/tests/test_serializers.py
@@ -12,62 +12,57 @@ from pantry.serializers import (
 
 
 class IngredientSerializerTest(TestCase):
+
     def test_serializes_all_expected_fields(self):
-        ingredient = Ingredient.objects.create(name="Olive Oil", unit="ml")
+        ingredient = Ingredient.objects.create(name="Olive Oil")
         data = IngredientSerializer(ingredient).data
-        self.assertEqual(set(data.keys()), {"id", "name", "unit"})
+        self.assertEqual(set(data.keys()), {"id", "name"})
         self.assertEqual(data["name"], "Olive Oil")
-        self.assertEqual(data["unit"], "ml")
 
     def test_creates_ingredient_from_valid_data(self):
-        serializer = IngredientSerializer(data={"name": "Butter", "unit": "g"})
+        serializer = IngredientSerializer(data={"name": "Butter"})
         self.assertTrue(serializer.is_valid())
         ingredient = serializer.save()
         self.assertEqual(ingredient.name, "Butter")
 
-    def test_unit_defaults_to_grams_when_no_value_provided(self):
-        serializer = IngredientSerializer(data={"name": "Salt"})
-        self.assertTrue(serializer.is_valid(), serializer.errors)
-        ingredient = serializer.save()
-        self.assertEqual(ingredient.unit, "g")
-
-    def test_rejects_invalid_unit_choice(self):
-        serializer = IngredientSerializer(data={"name": "Wrong unit", "unit": "xyz"})
-        self.assertFalse(serializer.is_valid())
-        self.assertIn("unit", serializer.errors)
-
     def test_rejects_duplicate_ingredient_name(self):
-        Ingredient.objects.create(name="Salt", unit="g")
-        serializer = IngredientSerializer(data={"name": "Salt", "unit": "kg"})
+        Ingredient.objects.create(name="Salt")
+        serializer = IngredientSerializer(data={"name": "Salt"})
         self.assertFalse(serializer.is_valid())
         self.assertIn("name", serializer.errors)
 
     def test_rejects_missing_name(self):
-        serializer = IngredientSerializer(data={"unit": "g"})
+        serializer = IngredientSerializer(data={})
         self.assertFalse(serializer.is_valid())
         self.assertIn("name", serializer.errors)
 
 
 class StockItemReadSerializerTest(TestCase):
+
     def setUp(self):
         self.user = User.objects.create_user(username="reader", password="pass")
-        self.ingredient = Ingredient.objects.create(name="Eggs", unit="pcs")
+        self.ingredient = Ingredient.objects.create(name="Eggs")
         self.stock = StockItem.objects.create(
-            user=self.user, ingredient=self.ingredient, quantity=12
+            user=self.user, ingredient=self.ingredient, quantity=12, unit="pcs"
         )
 
     def test_includes_all_expected_fields(self):
         data = StockItemReadSerializer(self.stock).data
         self.assertEqual(
             set(data.keys()),
-            {"id", "ingredient", "quantity", "expiry_date", "created_at", "updated_at"},
+            {"id", "ingredient", "unit", "quantity", "expiry_date", "created_at", "updated_at"},
         )
 
     def test_nests_full_ingredient_object(self):
         data = StockItemReadSerializer(self.stock).data
         self.assertIsInstance(data["ingredient"], dict)
+        self.assertEqual(set(data["ingredient"].keys()), {"id", "name"})
         self.assertEqual(data["ingredient"]["name"], "Eggs")
-        self.assertEqual(data["ingredient"]["unit"], "pcs")
+
+    def test_unit_is_at_stock_item_level(self):
+        data = StockItemReadSerializer(self.stock).data
+        self.assertEqual(data["unit"], "pcs")
+        self.assertNotIn("unit", data["ingredient"])
 
     def test_expiry_date_is_null_when_not_set(self):
         data = StockItemReadSerializer(self.stock).data
@@ -75,9 +70,10 @@ class StockItemReadSerializerTest(TestCase):
 
 
 class StockItemWriteSerializerTest(TestCase):
+
     def setUp(self):
         self.user = User.objects.create_user(username="writer", password="pass")
-        self.ingredient = Ingredient.objects.create(name="Flour", unit="g")
+        self.ingredient = Ingredient.objects.create(name="Flour")
 
     def _context(self):
         request = MagicMock()
@@ -86,18 +82,19 @@ class StockItemWriteSerializerTest(TestCase):
 
     def test_creates_stock_item_with_valid_data(self):
         serializer = StockItemWriteSerializer(
-            data={"ingredient_id": self.ingredient.pk, "quantity": "500.00"},
+            data={"ingredient_id": self.ingredient.pk, "unit": "g", "quantity": "500.00"},
             context=self._context(),
         )
         self.assertTrue(serializer.is_valid(), serializer.errors)
         stock = serializer.save()
         self.assertEqual(stock.user, self.user)
         self.assertEqual(stock.ingredient, self.ingredient)
+        self.assertEqual(stock.unit, "g")
         self.assertEqual(stock.quantity, 500)
 
     def test_assigns_requesting_user_on_create(self):
         serializer = StockItemWriteSerializer(
-            data={"ingredient_id": self.ingredient.pk, "quantity": "100.00"},
+            data={"ingredient_id": self.ingredient.pk, "unit": "kg", "quantity": "1.00"},
             context=self._context(),
         )
         self.assertTrue(serializer.is_valid(), serializer.errors)
@@ -106,7 +103,7 @@ class StockItemWriteSerializerTest(TestCase):
 
     def test_expiry_date_is_optional(self):
         serializer = StockItemWriteSerializer(
-            data={"ingredient_id": self.ingredient.pk, "quantity": "100.00"},
+            data={"ingredient_id": self.ingredient.pk, "unit": "g", "quantity": "100.00"},
             context=self._context(),
         )
         self.assertTrue(serializer.is_valid(), serializer.errors)
@@ -115,6 +112,7 @@ class StockItemWriteSerializerTest(TestCase):
         serializer = StockItemWriteSerializer(
             data={
                 "ingredient_id": self.ingredient.pk,
+                "unit": "g",
                 "quantity": "100.00",
                 "expiry_date": "2027-01-01",
             },
@@ -127,7 +125,7 @@ class StockItemWriteSerializerTest(TestCase):
     def test_duplicate_ingredient_for_same_user_is_rejected(self):
         StockItem.objects.create(user=self.user, ingredient=self.ingredient, quantity=100)
         serializer = StockItemWriteSerializer(
-            data={"ingredient_id": self.ingredient.pk, "quantity": "200.00"},
+            data={"ingredient_id": self.ingredient.pk, "unit": "g", "quantity": "200.00"},
             context=self._context(),
         )
         self.assertFalse(serializer.is_valid())
@@ -135,33 +133,34 @@ class StockItemWriteSerializerTest(TestCase):
 
     def test_duplicate_check_is_skipped_on_update(self):
         stock = StockItem.objects.create(
-            user=self.user, ingredient=self.ingredient, quantity=100
+            user=self.user, ingredient=self.ingredient, quantity=100, unit="g"
         )
         serializer = StockItemWriteSerializer(
             instance=stock,
-            data={"ingredient_id": self.ingredient.pk, "quantity": "999.00"},
+            data={"ingredient_id": self.ingredient.pk, "unit": "kg", "quantity": "999.00"},
             context=self._context(),
         )
         self.assertTrue(serializer.is_valid(), serializer.errors)
 
     def test_to_representation_returns_nested_ingredient_shape(self):
         stock = StockItem.objects.create(
-            user=self.user, ingredient=self.ingredient, quantity=100
+            user=self.user, ingredient=self.ingredient, quantity=100, unit="g"
         )
         serializer = StockItemWriteSerializer(
             instance=stock,
-            data={"ingredient_id": self.ingredient.pk, "quantity": "100.00"},
+            data={"ingredient_id": self.ingredient.pk, "unit": "g", "quantity": "100.00"},
             context=self._context(),
         )
         serializer.is_valid()
         representation = serializer.to_representation(stock)
         self.assertIn("ingredient", representation)
+        self.assertIn("unit", representation)
         self.assertEqual(representation["ingredient"]["name"], "Flour")
         self.assertNotIn("ingredient_id", representation)
 
     def test_invalid_ingredient_id_is_rejected(self):
         serializer = StockItemWriteSerializer(
-            data={"ingredient_id": 9999, "quantity": "100.00"},
+            data={"ingredient_id": 9999, "unit": "g", "quantity": "100.00"},
             context=self._context(),
         )
         self.assertFalse(serializer.is_valid())
@@ -169,8 +168,16 @@ class StockItemWriteSerializerTest(TestCase):
 
     def test_missing_quantity_is_rejected(self):
         serializer = StockItemWriteSerializer(
-            data={"ingredient_id": self.ingredient.pk},
+            data={"ingredient_id": self.ingredient.pk, "unit": "g"},
             context=self._context(),
         )
         self.assertFalse(serializer.is_valid())
         self.assertIn("quantity", serializer.errors)
+
+    def test_rejects_invalid_unit_choice(self):
+        serializer = StockItemWriteSerializer(
+            data={"ingredient_id": self.ingredient.pk, "unit": "xyz", "quantity": "100.00"},
+            context=self._context(),
+        )
+        self.assertFalse(serializer.is_valid())
+        self.assertIn("unit", serializer.errors)

--- a/pantry/tests/test_views.py
+++ b/pantry/tests/test_views.py
@@ -13,8 +13,8 @@ class IngredientListCreateViewTest(APITestCase):
     def setUp(self):
         self.user = User.objects.create_user(username="user1", password="pass")
         self.client.force_authenticate(user=self.user)
-        self.flour = Ingredient.objects.create(name="Flour", unit="g")
-        self.milk = Ingredient.objects.create(name="Milk", unit="L")
+        self.flour = Ingredient.objects.create(name="Flour")
+        self.milk = Ingredient.objects.create(name="Milk")
         self.url = reverse("ingredient-list-create")
 
     # Authentication
@@ -26,7 +26,7 @@ class IngredientListCreateViewTest(APITestCase):
 
     def test_create_requires_authentication(self):
         self.client.force_authenticate(user=None)
-        response = self.client.post(self.url, {"name": "Butter", "unit": "g"}, format="json")
+        response = self.client.post(self.url, {"name": "Butter"}, format="json")
         self.assertEqual(response.status_code, status.HTTP_403_FORBIDDEN)
 
     # List
@@ -57,37 +57,24 @@ class IngredientListCreateViewTest(APITestCase):
     # Create
 
     def test_create_ingredient_returns_201(self):
-        response = self.client.post(self.url, {"name": "Eggs", "unit": "pcs"}, format="json")
+        response = self.client.post(self.url, {"name": "Eggs"}, format="json")
         self.assertEqual(response.status_code, status.HTTP_201_CREATED)
 
     def test_create_ingredient_persists_to_database(self):
-        self.client.post(self.url, {"name": "Eggs", "unit": "pcs"}, format="json")
+        self.client.post(self.url, {"name": "Eggs"}, format="json")
         self.assertTrue(Ingredient.objects.filter(name="Eggs").exists())
 
-    def test_create_ingredient_response_contains_id_name_unit(self):
-        response = self.client.post(self.url, {"name": "Eggs", "unit": "pcs"}, format="json")
-        self.assertEqual(set(response.data.keys()), {"id", "name", "unit"})
+    def test_create_ingredient_response_contains_id_name(self):
+        response = self.client.post(self.url, {"name": "Eggs"}, format="json")
+        self.assertEqual(set(response.data.keys()), {"id", "name"})
         self.assertEqual(response.data["name"], "Eggs")
-        self.assertEqual(response.data["unit"], "pcs")
-
-    def test_create_ingredient_defaults_unit_to_grams(self):
-        response = self.client.post(self.url, {"name": "Salt"}, format="json")
-        self.assertEqual(response.status_code, status.HTTP_201_CREATED)
-        self.assertEqual(response.data["unit"], "g")
-
-    def test_create_ingredient_rejects_invalid_unit(self):
-        response = self.client.post(
-            self.url, {"name": "Mystery", "unit": "xyz"}, format="json"
-        )
-        self.assertEqual(response.status_code, status.HTTP_400_BAD_REQUEST)
-        self.assertIn("unit", response.data)
 
     def test_create_ingredient_rejects_duplicate_name(self):
-        response = self.client.post(self.url, {"name": "Flour", "unit": "kg"}, format="json")
+        response = self.client.post(self.url, {"name": "Flour"}, format="json")
         self.assertEqual(response.status_code, status.HTTP_400_BAD_REQUEST)
 
     def test_create_ingredient_rejects_missing_name(self):
-        response = self.client.post(self.url, {"unit": "g"}, format="json")
+        response = self.client.post(self.url, {}, format="json")
         self.assertEqual(response.status_code, status.HTTP_400_BAD_REQUEST)
 
 
@@ -96,8 +83,8 @@ class StockItemListCreateViewTest(APITestCase):
         self.user = User.objects.create_user(username="user1", password="pass")
         self.other_user = User.objects.create_user(username="user2", password="pass")
         self.client.force_authenticate(user=self.user)
-        self.flour = Ingredient.objects.create(name="Flour", unit="g")
-        self.milk = Ingredient.objects.create(name="Milk", unit="L")
+        self.flour = Ingredient.objects.create(name="Flour")
+        self.milk = Ingredient.objects.create(name="Milk")
         self.url = reverse("stock-list-create")
 
     # Authentication
@@ -135,14 +122,15 @@ class StockItemListCreateViewTest(APITestCase):
         item = response.data["results"][0]
         self.assertIn("ingredient", item)
         self.assertEqual(item["ingredient"]["name"], "Flour")
-        self.assertEqual(item["ingredient"]["unit"], "g")
+        self.assertIn("unit", item)
+        self.assertNotIn("unit", item["ingredient"])
 
     # Create
 
     def test_create_stock_item_returns_201(self):
         response = self.client.post(
             self.url,
-            {"ingredient_id": self.flour.pk, "quantity": "500.00"},
+            {"ingredient_id": self.flour.pk, "unit": "g", "quantity": "500.00"},
             format="json",
         )
         self.assertEqual(response.status_code, status.HTTP_201_CREATED)
@@ -150,27 +138,29 @@ class StockItemListCreateViewTest(APITestCase):
     def test_create_stock_item_is_scoped_to_requesting_user(self):
         self.client.post(
             self.url,
-            {"ingredient_id": self.flour.pk, "quantity": "500.00"},
+            {"ingredient_id": self.flour.pk, "unit": "g", "quantity": "500.00"},
             format="json",
         )
         stock = StockItem.objects.get(ingredient=self.flour)
         self.assertEqual(stock.user, self.user)
 
-    def test_create_stock_item_response_has_nested_ingredient(self):
+    def test_create_stock_item_response_has_nested_ingredient_and_unit_at_top_level(self):
         response = self.client.post(
             self.url,
-            {"ingredient_id": self.flour.pk, "quantity": "500.00"},
+            {"ingredient_id": self.flour.pk, "unit": "g", "quantity": "500.00"},
             format="json",
         )
         self.assertIn("ingredient", response.data)
         self.assertEqual(response.data["ingredient"]["name"], "Flour")
-        self.assertEqual(response.data["ingredient"]["unit"], "g")
+        self.assertEqual(response.data["unit"], "g")
+        self.assertNotIn("unit", response.data["ingredient"])
 
     def test_create_stock_item_with_expiry_date(self):
         response = self.client.post(
             self.url,
             {
                 "ingredient_id": self.flour.pk,
+                "unit": "g",
                 "quantity": "500.00",
                 "expiry_date": "2027-06-01",
             },
@@ -183,20 +173,20 @@ class StockItemListCreateViewTest(APITestCase):
         StockItem.objects.create(user=self.user, ingredient=self.flour, quantity=100)
         response = self.client.post(
             self.url,
-            {"ingredient_id": self.flour.pk, "quantity": "200.00"},
+            {"ingredient_id": self.flour.pk, "unit": "g", "quantity": "200.00"},
             format="json",
         )
         self.assertEqual(response.status_code, status.HTTP_400_BAD_REQUEST)
 
     def test_create_invalid_ingredient_id_returns_400(self):
         response = self.client.post(
-            self.url, {"ingredient_id": 9999, "quantity": "100.00"}, format="json"
+            self.url, {"ingredient_id": 9999, "unit": "g", "quantity": "100.00"}, format="json"
         )
         self.assertEqual(response.status_code, status.HTTP_400_BAD_REQUEST)
 
     def test_create_missing_quantity_returns_400(self):
         response = self.client.post(
-            self.url, {"ingredient_id": self.flour.pk}, format="json"
+            self.url, {"ingredient_id": self.flour.pk, "unit": "g"}, format="json"
         )
         self.assertEqual(response.status_code, status.HTTP_400_BAD_REQUEST)
 
@@ -205,7 +195,7 @@ class StockItemListCreateViewTest(APITestCase):
         self.client.force_authenticate(user=self.other_user)
         response = self.client.post(
             self.url,
-            {"ingredient_id": self.flour.pk, "quantity": "300.00"},
+            {"ingredient_id": self.flour.pk, "unit": "kg", "quantity": "1.00"},
             format="json",
         )
         self.assertEqual(response.status_code, status.HTTP_201_CREATED)
@@ -216,10 +206,10 @@ class StockItemDetailViewTest(APITestCase):
         self.user = User.objects.create_user(username="user1", password="pass")
         self.other_user = User.objects.create_user(username="user2", password="pass")
         self.client.force_authenticate(user=self.user)
-        self.flour = Ingredient.objects.create(name="Flour", unit="g")
-        self.milk = Ingredient.objects.create(name="Milk", unit="L")
+        self.flour = Ingredient.objects.create(name="Flour")
+        self.milk = Ingredient.objects.create(name="Milk")
         self.stock = StockItem.objects.create(
-            user=self.user, ingredient=self.flour, quantity=500
+            user=self.user, ingredient=self.flour, quantity=500, unit="g"
         )
         self.url = reverse("stock-detail", args=[self.stock.pk])
 
@@ -243,7 +233,7 @@ class StockItemDetailViewTest(APITestCase):
 
     def test_retrieve_other_users_item_returns_404(self):
         other_stock = StockItem.objects.create(
-            user=self.other_user, ingredient=self.milk, quantity=2
+            user=self.other_user, ingredient=self.milk, quantity=2, unit="L"
         )
         response = self.client.get(reverse("stock-detail", args=[other_stock.pk]))
         self.assertEqual(response.status_code, status.HTTP_404_NOT_FOUND)
@@ -255,6 +245,7 @@ class StockItemDetailViewTest(APITestCase):
             self.url,
             {
                 "ingredient_id": self.flour.pk,
+                "unit": "g",
                 "quantity": "999.00",
                 "expiry_date": "2028-01-01",
             },
@@ -268,7 +259,7 @@ class StockItemDetailViewTest(APITestCase):
     def test_put_response_has_nested_ingredient(self):
         response = self.client.put(
             self.url,
-            {"ingredient_id": self.flour.pk, "quantity": "200.00"},
+            {"ingredient_id": self.flour.pk, "unit": "g", "quantity": "200.00"},
             format="json",
         )
         self.assertIn("ingredient", response.data)
@@ -276,11 +267,11 @@ class StockItemDetailViewTest(APITestCase):
 
     def test_put_other_users_item_returns_404(self):
         other_stock = StockItem.objects.create(
-            user=self.other_user, ingredient=self.milk, quantity=2
+            user=self.other_user, ingredient=self.milk, quantity=2, unit="L"
         )
         response = self.client.put(
             reverse("stock-detail", args=[other_stock.pk]),
-            {"ingredient_id": self.milk.pk, "quantity": "5.00"},
+            {"ingredient_id": self.milk.pk, "unit": "L", "quantity": "5.00"},
             format="json",
         )
         self.assertEqual(response.status_code, status.HTTP_404_NOT_FOUND)
@@ -311,7 +302,7 @@ class StockItemDetailViewTest(APITestCase):
 
     def test_patch_other_users_item_returns_404(self):
         other_stock = StockItem.objects.create(
-            user=self.other_user, ingredient=self.milk, quantity=2
+            user=self.other_user, ingredient=self.milk, quantity=2, unit="L"
         )
         response = self.client.patch(
             reverse("stock-detail", args=[other_stock.pk]),
@@ -329,7 +320,7 @@ class StockItemDetailViewTest(APITestCase):
 
     def test_delete_other_users_item_returns_404_and_does_not_delete(self):
         other_stock = StockItem.objects.create(
-            user=self.other_user, ingredient=self.milk, quantity=2
+            user=self.other_user, ingredient=self.milk, quantity=2, unit="L"
         )
         response = self.client.delete(reverse("stock-detail", args=[other_stock.pk]))
         self.assertEqual(response.status_code, status.HTTP_404_NOT_FOUND)
@@ -347,8 +338,8 @@ class RecipeMatchViewTest(APITestCase):
         self.user = User.objects.create_user(username="test@email.com", password="SecurePass123!")
         self.other_user = User.objects.create_user(username="othertest@email.com", password="SecurePass234!")
         self.client.force_authenticate(user=self.user)
-        self.flour = Ingredient.objects.create(name="Flour", unit="g")
-        self.milk = Ingredient.objects.create(name="Milk", unit="L")
+        self.flour = Ingredient.objects.create(name="Flour")
+        self.milk = Ingredient.objects.create(name="Milk")
         self.url = reverse("recipe-match")
         self.expected_recipe = {
             "id": 1,

--- a/pantry/views.py
+++ b/pantry/views.py
@@ -70,7 +70,7 @@ class PantryPageView(TemplateView):
 
     def get_context_data(self, **kwargs):
         context = super().get_context_data(**kwargs)
-        context["unit_choices"] = Ingredient.Unit.choices
+        context["unit_choices"] = StockItem.Unit.choices
         return context
 
 


### PR DESCRIPTION
## Summary

This PR refactors the inventory management system to separate ingredients from their measurement units. It allows users to define their preferred unit system within their pantry.

## Type of change

<!-- Mark the applicable option with an [x]. -->

- [ ] Bug fix
- [x] New feature
- [ ] Refactor (no functional change)
- [ ] Tests only
- [ ] Documentation
- [ ] Configuration / DevOps

## Related issue(s)

Closes #59 

## Changes made


- Removed `unit` field from `Ingredient` and added it in `StockItem`
- The `Unit` inner class was moved to `StockItem`
**`StockItemWriteSerializer`**: `unit` added to fields.
- `unit_choices` for `PantryPageView` now sourced from `StockItem.Unit.choices`
- Created custom migration to copy the relevant data

## Testing

- [x] I have added or updated tests to cover my changes
- [x] All new and existing tests pass locally (`python manage.py test pantry`)
- [x] Test coverage has not dropped below 80 %

