### PR TITLE
Feature/68 cachedrecipes

### DIFF
--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -1,8 +1,10 @@
 #!/bin/sh
 
-# Wait for DB if necessary (optional but good)
 echo "Running migrations..."
 python manage.py migrate --noinput
+
+echo "Creating cache table"
+python manage.py createcachetable
 
 # Start Gunicorn
 echo "Starting server..."

--- a/pantry/migrations/0004_cachedrecipe.py
+++ b/pantry/migrations/0004_cachedrecipe.py
@@ -1,0 +1,29 @@
+from django.db import migrations, models
+
+
+class Migration(migrations.Migration):
+
+    dependencies = [
+        ("pantry", "0003_move_unit_to_stockitem"),
+    ]
+
+    operations = [
+        migrations.CreateModel(
+            name="CachedRecipe",
+            fields=[
+                ("id", models.BigAutoField(auto_created=True, primary_key=True, serialize=False, verbose_name="ID")),
+                ("recipe_id", models.IntegerField(unique=True)),
+                ("title", models.CharField(max_length=500)),
+                ("image", models.URLField(blank=True, default="")),
+                ("ready_in_minutes", models.IntegerField(blank=True, null=True)),
+                ("prep_minutes", models.IntegerField(blank=True, null=True)),
+                ("cook_minutes", models.IntegerField(blank=True, null=True)),
+                ("nutrition", models.JSONField(default=list)),
+                ("instructions", models.JSONField(default=list)),
+                ("cached_at", models.DateTimeField(auto_now=True)),
+            ],
+            options={
+                "ordering": ["recipe_id"],
+            },
+        ),
+    ]

--- a/pantry/models.py
+++ b/pantry/models.py
@@ -52,3 +52,44 @@ class SavedRecipe(models.Model):
 
     def __str__(self):
         return f"{self.user.username} – {self.title}"
+
+
+class CachedRecipe(models.Model):
+    """
+    Local cache for Spoonacular recipe detail data.
+
+    Records are considered fresh for RECIPE_DETAIL_CACHE_DAYS days.  After that
+    the service layer will re-fetch from the API and update this row in place.
+    """
+
+    recipe_id = models.IntegerField(unique=True)
+    title = models.CharField(max_length=500)
+    image = models.URLField(blank=True, default="")
+    ready_in_minutes = models.IntegerField(null=True, blank=True)
+    prep_minutes = models.IntegerField(null=True, blank=True)
+    cook_minutes = models.IntegerField(null=True, blank=True)
+    # Stored as a list of {name, amount, unit} dicts.
+    nutrition = models.JSONField(default=list)
+    # Stored as a list of {number, step} dicts.
+    instructions = models.JSONField(default=list)
+    # Updated every time the record is refreshed from the API.
+    cached_at = models.DateTimeField(auto_now=True)
+
+    class Meta:
+        ordering = ["recipe_id"]
+
+    def __str__(self):
+        return f"CachedRecipe({self.recipe_id}: {self.title})"
+
+    def to_detail_dict(self) -> dict:
+        """Return the same structure that get_recipe_details() produces."""
+        return {
+            "id": self.recipe_id,
+            "title": self.title,
+            "image": self.image,
+            "ready_in_minutes": self.ready_in_minutes,
+            "prep_minutes": self.prep_minutes,
+            "cook_minutes": self.cook_minutes,
+            "nutrition": self.nutrition,
+            "instructions": self.instructions,
+        }

--- a/pantry/services.py
+++ b/pantry/services.py
@@ -25,7 +25,6 @@ SPOONACULAR_INTOLERANCE_MAP = {
 }
 
 
-
 class SpoonacularError(Exception):
     """
     Raised when the Spoonacular API returns an unexpected response.

--- a/pantry/services.py
+++ b/pantry/services.py
@@ -1,5 +1,11 @@
+import hashlib
 import requests
+from datetime import timedelta
+
 from django.conf import settings
+from django.core.cache import cache
+from django.utils import timezone
+from .models import CachedRecipe
 
 SPOONACULAR_BASE_URL = "https://api.spoonacular.com"
 # Timeout in seconds
@@ -17,6 +23,7 @@ SPOONACULAR_INTOLERANCE_MAP = {
     "dairy_free": "dairy",
     "nut_free": "tree nut,peanut",
 }
+
 
 
 class SpoonacularError(Exception):
@@ -52,6 +59,20 @@ def _build_diet_params(diets: list[str]) -> dict:
     return params
 
 
+def _search_cache_key(ingredient_names: list[str], diets: list[str] | None) -> str:
+    """
+    Build a cache key for an ingredient search
+
+    The key is an MD5 hash of the sorted ingredients and sorted diets so that
+    the same query always maps to the same key regardless of input order
+    """
+    parts = sorted(ingredient_names)
+    if diets:
+        parts.append("diets:" + ",".join(sorted(diets)))
+    hex_digest = hashlib.md5("|".join(parts).encode()).hexdigest()
+    return f"recipe_search:{hex_digest}"
+
+
 def find_recipes_by_ingredients(
     ingredient_names: list[str],
     number: int = 12,
@@ -80,6 +101,12 @@ def find_recipes_by_ingredients(
     api_key = settings.SPOONACULAR_API_KEY
     if not api_key:
         raise SpoonacularError("Spoonacular API key is not configured. Set SPOONACULAR_API_KEY in your environment.")
+
+    # Check for cached result before making API request
+    cache_key = _search_cache_key(ingredient_names, diets)
+    cached = cache.get(cache_key)
+    if cached is not None:
+        return cached
 
     use_complex_search = bool(diets)
 
@@ -123,7 +150,7 @@ def find_recipes_by_ingredients(
     # complexSearch wraps results, findByIngredients returns a bare list.
     items = raw.get("results", raw) if isinstance(raw, dict) else raw
 
-    return [
+    results = [
         {
             "id": item["id"],
             "title": item["title"],
@@ -136,10 +163,20 @@ def find_recipes_by_ingredients(
         for item in items
     ]
 
+    # Store result on cache for the defined time on SEARCH_CACHE_TTL
+    cache.set(cache_key, results, timeout=settings.SEARCH_CACHE_TTL)
+
+    return results
+
 
 def get_recipe_details(recipe_id: int) -> dict:
     """
-    Request to Spoonacular /recipes/{id}/information endpoint.
+    Returns detail data for a single Spoonacular recipe
+
+    Uses the local CachedRecipe table with the following strategy:
+      1. If a CachedRecipe row exists and is within RECIPE_DETAIL_CACHE_DAYS, return it
+      2. Otherwise fetch from the Spoonacular API
+      3. Insert/Update the result into CachedRecipe and return the fresh data
 
     Args:
         recipe_id   - Spoonacular recipe ID.
@@ -152,6 +189,13 @@ def get_recipe_details(recipe_id: int) -> dict:
     Raises a SpoonacularError if the API key is missing, the recipe is not found,
     the API is unreachable, or the API returns a non-200 response.
     """
+
+    # Check for CachedRecipe before making API request
+    cutoff = timezone.now() - timedelta(days=settings.RECIPE_DETAIL_CACHE_DAYS)
+    cached = CachedRecipe.objects.filter(recipe_id=recipe_id, cached_at__gte=cutoff).first()
+    if cached:
+        return cached.to_detail_dict()
+
     api_key = settings.SPOONACULAR_API_KEY
     if not api_key:
         raise SpoonacularError("Spoonacular API key is not configured. Set SPOONACULAR_API_KEY in your environment.")
@@ -199,7 +243,7 @@ def get_recipe_details(recipe_id: int) -> dict:
         """
         return None if value == -1 else value
 
-    return {
+    detail = {
         "id": data["id"],
         "title": data["title"],
         "image": data.get("image", ""),
@@ -209,3 +253,19 @@ def get_recipe_details(recipe_id: int) -> dict:
         "nutrition": nutrients,
         "instructions": instructions,
     }
+
+    # Store result on cache for the defined time on SEARCH_CACHE_TTL
+    CachedRecipe.objects.update_or_create(
+        recipe_id=recipe_id,
+        defaults={
+            "title": detail["title"],
+            "image": detail["image"],
+            "ready_in_minutes": detail["ready_in_minutes"],
+            "prep_minutes": detail["prep_minutes"],
+            "cook_minutes": detail["cook_minutes"],
+            "nutrition": detail["nutrition"],
+            "instructions": detail["instructions"],
+        },
+    )
+
+    return detail

--- a/pantry/services.py
+++ b/pantry/services.py
@@ -68,7 +68,7 @@ def _search_cache_key(ingredient_names: list[str], diets: list[str] | None) -> s
     parts = sorted(ingredient_names)
     if diets:
         parts.append("diets:" + ",".join(sorted(diets)))
-    hex_digest = hashlib.md5("|".join(parts).encode()).hexdigest()
+    hex_digest = hashlib.md5("|".join(parts).encode(), usedforsecurity=False).hexdigest()
     return f"recipe_search:{hex_digest}"
 
 

--- a/pantry/tests/test_models.py
+++ b/pantry/tests/test_models.py
@@ -5,7 +5,7 @@ from django.contrib.auth.models import User
 from django.db import IntegrityError
 from django.test import TestCase
 
-from pantry.models import Ingredient, StockItem, SavedRecipe
+from pantry.models import CachedRecipe, Ingredient, StockItem, SavedRecipe
 
 
 class IngredientModelTest(TestCase):
@@ -137,3 +137,66 @@ class SavedRecipeModelTest(TestCase):
         newest = SavedRecipe.objects.create(user=self.user, recipe_id=2, title="Second")
         qs = list(SavedRecipe.objects.filter(user=self.user))
         self.assertEqual(qs[0].pk, newest.pk)
+
+
+class CachedRecipeModelTest(TestCase):
+
+    def _create(self, recipe_id=42, **kwargs):
+        defaults = {
+            "title": "Pasta Bolognese",
+            "image": "https://example.com/pasta.jpg",
+            "ready_in_minutes": 60,
+            "prep_minutes": 15,
+            "cook_minutes": 45,
+            "nutrition": [{"name": "Calories", "amount": 550, "unit": "kcal"}],
+            "instructions": [{"number": 1, "step": "Boil pasta."}],
+        }
+        defaults.update(kwargs)
+        return CachedRecipe.objects.create(recipe_id=recipe_id, **defaults)
+
+    def test_str_representation(self):
+        recipe = self._create()
+        self.assertEqual(str(recipe), "CachedRecipe(42: Pasta Bolognese)")
+
+    def test_recipe_id_is_unique(self):
+        self._create(recipe_id=1)
+        with self.assertRaises(IntegrityError):
+            self._create(recipe_id=1)
+
+    def test_image_defaults_to_empty_string(self):
+        recipe = CachedRecipe.objects.create(recipe_id=99, title="No Image")
+        self.assertEqual(recipe.image, "")
+
+    def test_optional_timing_fields_accept_null(self):
+        recipe = CachedRecipe.objects.create(
+            recipe_id=100, title="Unknown Timing",
+            ready_in_minutes=None, prep_minutes=None, cook_minutes=None,
+        )
+        self.assertIsNone(recipe.prep_minutes)
+        self.assertIsNone(recipe.cook_minutes)
+
+    def test_cached_at_is_set_automatically(self):
+        recipe = self._create()
+        self.assertIsNotNone(recipe.cached_at)
+
+    def test_to_detail_dict_returns_correct_shape(self):
+        recipe = self._create()
+        result = recipe.to_detail_dict()
+        self.assertEqual(result["id"], 42)
+        self.assertEqual(result["title"], "Pasta Bolognese")
+        self.assertEqual(result["ready_in_minutes"], 60)
+        self.assertEqual(result["nutrition"], [{"name": "Calories", "amount": 550, "unit": "kcal"}])
+        self.assertEqual(result["instructions"], [{"number": 1, "step": "Boil pasta."}])
+
+    def test_to_detail_dict_does_not_expose_pk(self):
+        recipe = self._create()
+        result = recipe.to_detail_dict()
+        self.assertNotIn("pk", result)
+        self.assertNotIn("cached_at", result)
+
+    def test_ordering_is_by_recipe_id(self):
+        self._create(recipe_id=30)
+        self._create(recipe_id=10)
+        self._create(recipe_id=20)
+        ids = list(CachedRecipe.objects.values_list("recipe_id", flat=True))
+        self.assertEqual(ids, [10, 20, 30])

--- a/pantry/tests/test_services.py
+++ b/pantry/tests/test_services.py
@@ -633,5 +633,6 @@ class RecipeDetailCacheTest(TestCase):
             instructions=[{"number": 1, "step": "Boil pasta."}],
         )
         result = get_recipe_details(self.recipe_id)
-        expected_keys = {"id", "title", "image", "ready_in_minutes", "prep_minutes", "cook_minutes", "nutrition", "instructions"}
+        expected_keys = {"id", "title", "image", "ready_in_minutes", "prep_minutes",
+                         "cook_minutes", "nutrition", "instructions"}
         self.assertEqual(set(result.keys()), expected_keys)

--- a/pantry/tests/test_services.py
+++ b/pantry/tests/test_services.py
@@ -1,15 +1,21 @@
 from unittest.mock import patch
 
 import requests
+from datetime import timedelta
+
+from django.core.cache import cache
 from django.test import TestCase, override_settings
+from django.utils import timezone
 from pantry.services import (
     SpoonacularError,
     _build_diet_params,
+    _search_cache_key,
     find_recipes_by_ingredients,
     get_recipe_details,
 )
 
 
+@override_settings(CACHES={"default": {"BACKEND": "django.core.cache.backends.dummy.DummyCache"}})
 class RecipeSuggestionsServiceTest(TestCase):
 
     def setUp(self):
@@ -130,6 +136,7 @@ class RecipeSuggestionsServiceTest(TestCase):
         self.assertEqual(result[0]["image"], "")
 
 
+@override_settings(CACHES={"default": {"BACKEND": "django.core.cache.backends.dummy.DummyCache"}})
 class RecipeDietaryFilteringServiceTest(TestCase):
 
     def test_empty_diets_returns_empty_params(self):
@@ -246,6 +253,7 @@ class RecipeDietaryFilteringServiceTest(TestCase):
         self.assertNotIn("intolerances", sent_params)
 
 
+@override_settings(CACHES={"default": {"BACKEND": "django.core.cache.backends.dummy.DummyCache"}})
 class RecipeDetailServiceTest(TestCase):
 
     def setUp(self):
@@ -393,3 +401,237 @@ class RecipeDetailServiceTest(TestCase):
         result = get_recipe_details(42)
 
         self.assertEqual(result["nutrition"], [])
+
+
+class SearchCacheKeyTest(TestCase):
+
+    def test_same_ingredients_produce_same_key(self):
+        k1 = _search_cache_key(["Flour", "Milk"], None)
+        k2 = _search_cache_key(["Flour", "Milk"], None)
+        self.assertEqual(k1, k2)
+
+    def test_same_ingredient_different_order_produce_same_key(self):
+        k1 = _search_cache_key(["Flour", "Milk"], None)
+        k2 = _search_cache_key(["Milk", "Flour"], None)
+        self.assertEqual(k1, k2)
+
+    def test_different_ingredients_produce_different_keys(self):
+        k1 = _search_cache_key(["Flour"], None)
+        k2 = _search_cache_key(["Eggs"], None)
+        self.assertNotEqual(k1, k2)
+
+    def test_diets_are_included_in_key(self):
+        k1 = _search_cache_key(["Flour"], None)
+        k2 = _search_cache_key(["Flour"], ["vegan"])
+        self.assertNotEqual(k1, k2)
+
+    def test_same_ingredient_same_diets_different_order_produce_same_key(self):
+        k1 = _search_cache_key(["Flour"], ["vegan", "gluten_free"])
+        k2 = _search_cache_key(["Flour"], ["gluten_free", "vegan"])
+        self.assertEqual(k1, k2)
+
+    def test_key_has_expected_prefix(self):
+        key = _search_cache_key(["Flour"], None)
+        self.assertTrue(key.startswith("recipe_search:"))
+
+
+@override_settings(
+    SPOONACULAR_API_KEY="test-key",
+    CACHES={"default": {"BACKEND": "django.core.cache.backends.locmem.LocMemCache"}},
+)
+class FindRecipesByIngredientsCacheTest(TestCase):
+
+    def setUp(self):
+        cache.clear()
+        self.api_response = [
+            {
+                "id": 1,
+                "title": "Pancakes",
+                "image": "https://example.com/pancakes.jpg",
+                "usedIngredientCount": 2,
+                "missedIngredientCount": 1,
+                "usedIngredients": [{"name": "Flour"}, {"name": "Milk"}],
+                "missedIngredients": [{"name": "Eggs"}],
+            }
+        ]
+        self.expected = [
+            {
+                "id": 1,
+                "title": "Pancakes",
+                "image": "https://example.com/pancakes.jpg",
+                "used_count": 2,
+                "missed_count": 1,
+                "used_ingredients": ["Flour", "Milk"],
+                "missed_ingredients": ["Eggs"],
+            }
+        ]
+
+    def tearDown(self):
+        cache.clear()
+
+    @patch("pantry.services.requests.get")
+    def test_cache_miss_calls_api_and_stores_result(self, mock_get):
+        mock_get.return_value.ok = True
+        mock_get.return_value.status_code = 200
+        mock_get.return_value.json.return_value = self.api_response
+
+        result = find_recipes_by_ingredients(["Flour", "Milk"])
+
+        mock_get.assert_called_once()
+        self.assertEqual(result, self.expected)
+
+        key = _search_cache_key(["Flour", "Milk"], None)
+        self.assertEqual(cache.get(key), self.expected)
+
+    @patch("pantry.services.requests.get")
+    def test_cache_hit_skips_api_call(self, mock_get):
+        key = _search_cache_key(["Flour", "Milk"], None)
+        cache.set(key, self.expected, timeout=60)
+
+        result = find_recipes_by_ingredients(["Flour", "Milk"])
+
+        mock_get.assert_not_called()
+        self.assertEqual(result, self.expected)
+
+    @patch("pantry.services.requests.get")
+    def test_different_ingredients_use_different_cache_entries(self, mock_get):
+        mock_get.return_value.ok = True
+        mock_get.return_value.status_code = 200
+        mock_get.return_value.json.return_value = self.api_response
+
+        find_recipes_by_ingredients(["Flour"])
+        find_recipes_by_ingredients(["Eggs"])
+
+        self.assertEqual(mock_get.call_count, 2)
+
+    @patch("pantry.services.requests.get")
+    def test_api_error_does_not_populate_cache(self, mock_get):
+        mock_get.return_value.ok = False
+        mock_get.return_value.status_code = 500
+
+        with self.assertRaises(SpoonacularError):
+            find_recipes_by_ingredients(["Flour"])
+
+        key = _search_cache_key(["Flour"], None)
+        self.assertIsNone(cache.get(key))
+
+    @patch("pantry.services.requests.get")
+    def test_diets_param_uses_separate_cache_entry(self, mock_get):
+        mock_get.return_value.ok = True
+        mock_get.return_value.status_code = 200
+        mock_get.return_value.json.return_value = {"results": []}
+
+        find_recipes_by_ingredients(["Flour"])
+        find_recipes_by_ingredients(["Flour"], diets=["vegan"])
+
+        self.assertEqual(mock_get.call_count, 2)
+
+
+@override_settings(
+    SPOONACULAR_API_KEY="test-key",
+    RECIPE_DETAIL_CACHE_DAYS=30,
+)
+class RecipeDetailCacheTest(TestCase):
+
+    def setUp(self):
+        from pantry.models import CachedRecipe
+        self.CachedRecipe = CachedRecipe
+        self.recipe_id = 42
+        self.api_response = {
+            "id": 42,
+            "title": "Spaghetti Bolognese",
+            "image": "https://example.com/spag.jpg",
+            "readyInMinutes": 60,
+            "preparationMinutes": 15,
+            "cookingMinutes": 45,
+            "nutrition": {
+                "nutrients": [
+                    {"name": "Calories", "amount": 550, "unit": "kcal"},
+                ]
+            },
+            "analyzedInstructions": [
+                {"name": "", "steps": [{"number": 1, "step": "Boil pasta."}]},
+            ],
+        }
+
+    @patch("pantry.services.requests.get")
+    def test_cache_miss_fetches_api_and_saves_to_db(self, mock_get):
+        mock_get.return_value.ok = True
+        mock_get.return_value.status_code = 200
+        mock_get.return_value.json.return_value = self.api_response
+
+        result = get_recipe_details(self.recipe_id)
+
+        mock_get.assert_called_once()
+        self.assertEqual(result["title"], "Spaghetti Bolognese")
+        self.assertTrue(self.CachedRecipe.objects.filter(recipe_id=self.recipe_id).exists())
+
+    @patch("pantry.services.requests.get")
+    def test_fresh_db_record_skips_api_call(self, mock_get):
+        self.CachedRecipe.objects.create(
+            recipe_id=self.recipe_id,
+            title="Spaghetti Bolognese",
+            image="https://example.com/spag.jpg",
+            ready_in_minutes=60,
+            prep_minutes=15,
+            cook_minutes=45,
+            nutrition=[{"name": "Calories", "amount": 550, "unit": "kcal"}],
+            instructions=[{"number": 1, "step": "Boil pasta."}],
+        )
+
+        result = get_recipe_details(self.recipe_id)
+
+        mock_get.assert_not_called()
+        self.assertEqual(result["title"], "Spaghetti Bolognese")
+
+    @patch("pantry.services.requests.get")
+    def test_stale_db_record_triggers_api_refresh(self, mock_get):
+        mock_get.return_value.ok = True
+        mock_get.return_value.status_code = 200
+        mock_get.return_value.json.return_value = self.api_response
+
+        record = self.CachedRecipe.objects.create(
+            recipe_id=self.recipe_id,
+            title="Old Title",
+            nutrition=[], instructions=[],
+        )
+        stale_time = timezone.now() - timedelta(days=31)
+        self.CachedRecipe.objects.filter(pk=record.pk).update(cached_at=stale_time)
+
+        result = get_recipe_details(self.recipe_id)
+
+        mock_get.assert_called_once()
+        self.assertEqual(result["title"], "Spaghetti Bolognese")
+
+    @patch("pantry.services.requests.get")
+    def test_api_result_upserts_existing_record(self, mock_get):
+        mock_get.return_value.ok = True
+        mock_get.return_value.status_code = 200
+        mock_get.return_value.json.return_value = self.api_response
+
+        self.CachedRecipe.objects.create(
+            recipe_id=self.recipe_id, title="Old Title", nutrition=[], instructions=[]
+        )
+        stale_time = timezone.now() - timedelta(days=31)
+        self.CachedRecipe.objects.filter(recipe_id=self.recipe_id).update(cached_at=stale_time)
+
+        get_recipe_details(self.recipe_id)
+
+        self.assertEqual(self.CachedRecipe.objects.filter(recipe_id=self.recipe_id).count(), 1)
+        updated = self.CachedRecipe.objects.get(recipe_id=self.recipe_id)
+        self.assertEqual(updated.title, "Spaghetti Bolognese")
+
+    def test_fresh_cache_returns_to_detail_dict_shape(self):
+        self.CachedRecipe.objects.create(
+            recipe_id=self.recipe_id,
+            title="Spaghetti Bolognese",
+            image="https://example.com/spag.jpg",
+            ready_in_minutes=60,
+            prep_minutes=15,
+            cook_minutes=45,
+            nutrition=[{"name": "Calories", "amount": 550, "unit": "kcal"}],
+            instructions=[{"number": 1, "step": "Boil pasta."}],
+        )
+        result = get_recipe_details(self.recipe_id)
+        expected_keys = {"id", "title", "image", "ready_in_minutes", "prep_minutes", "cook_minutes", "nutrition", "instructions"}
+        self.assertEqual(set(result.keys()), expected_keys)

--- a/stockpot/settings.py
+++ b/stockpot/settings.py
@@ -81,6 +81,28 @@ DEFAULT_AUTO_FIELD = "django.db.models.BigAutoField"
 
 SPOONACULAR_API_KEY = config("SPOONACULAR_API_KEY", default="")
 
+# Cache settings
+# Defaults to in-process memory cache (so there's no extra infra needed in development).
+# For production, point CACHE_BACKEND should be pointed to a Redis backend and
+# CACHE_LOCATION to the Redis URL
+# TODO: Spin up a real Redis instance for production and update these settings accordingly. Meanwhile the inMemCache
+#  will be used in production as well, which is not ideal but enough for this stage
+CACHES = {
+    "default": {
+        "BACKEND": config(
+            "CACHE_BACKEND",
+            default="django.core.cache.backends.locmem.LocMemCache",
+        ),
+        "LOCATION": config("CACHE_LOCATION", default="stockpot"),
+    }
+}
+
+# Ingredient search results are cached for 24 hours.
+SEARCH_CACHE_TTL = 60 * 60 * 24
+
+# Recipe detail records older than this many days are re-fetched from the API.
+RECIPE_DETAIL_CACHE_DAYS = 30
+
 REST_FRAMEWORK = {
     "DEFAULT_RENDERER_CLASSES": [
         "rest_framework.renderers.JSONRenderer",

--- a/stockpot/settings.py
+++ b/stockpot/settings.py
@@ -82,18 +82,10 @@ DEFAULT_AUTO_FIELD = "django.db.models.BigAutoField"
 SPOONACULAR_API_KEY = config("SPOONACULAR_API_KEY", default="")
 
 # Cache settings
-# Defaults to in-process memory cache (so there's no extra infra needed in development).
-# For production, point CACHE_BACKEND should be pointed to a Redis backend and
-# CACHE_LOCATION to the Redis URL
-# TODO: Spin up a real Redis instance for production and update these settings accordingly. Meanwhile the inMemCache
-#  will be used in production as well, which is not ideal but enough for this stage
 CACHES = {
-    "default": {
-        "BACKEND": config(
-            "CACHE_BACKEND",
-            default="django.core.cache.backends.locmem.LocMemCache",
-        ),
-        "LOCATION": config("CACHE_LOCATION", default="stockpot"),
+    'default': {
+        'BACKEND': 'django.core.cache.backends.db.DatabaseCache',
+        'LOCATION': 'stockpot_cache_table',
     }
 }
 


### PR DESCRIPTION
## Summary

This PR implements a two-tier caching layer for the Spoonacular API integration.

## Type of change

- [ ] Bug fix
- [x] New feature
- [ ]  Refactor (no functional change)
- [ ] Tests only
- [ ] Documentation
- [ ] Configuration / DevOps

## Related issue(s)

Closes #68 

## Changes made

- Added `CACHES` configuration
- Added `SEARCH_CACHE_TTL = 86400` (24 hours)
- Added `RECIPE_DETAIL_CACHE_DAYS = 30`
- Created `CachedRecipe` model for saving cached Recipe details
- Added `_search_cache_key(ingredients, diets)` function that automatically creates a hash key for caching responses of Ingredient search
- Added cache functionality to `find_recipes_by_ingredients()` and `get_recipe_details()`

## Testing

- [x] I have added or updated tests to cover my changes
- [x] All new and existing tests pass locally (`python manage.py test pantry`)
- [x] Test coverage has not dropped below 80 %
