### PR TITLE
Feature/61 sentence case

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -7,8 +7,8 @@
 <!-- Mark the applicable option with an [x]. -->
 
 - [ ] Bug fix
-- [ ] New feature
-- [ ]️ Refactor (no functional change)
+- [ ] New feature 
+- [ ] Refactor (no functional change)
 - [ ] Tests only
 - [ ] Documentation
 - [ ] Configuration / DevOps

--- a/pantry/migrations/0005_normalise_ingredient_names.py
+++ b/pantry/migrations/0005_normalise_ingredient_names.py
@@ -1,0 +1,39 @@
+"""
+Manual migration to capitalise the first letter of every Ingredient name.
+
+If a capitalised variant already exists (e.g. both "milk" and "Milk" are
+stored), all StockItems that reference the lower-cased record are re-pointed
+to the capitalised record, and the duplicate is then deleted.
+"""
+
+from django.db import migrations
+
+
+def normalise_ingredient_names(apps, schema_editor):
+    Ingredient = apps.get_model("pantry", "Ingredient")
+    StockItem = apps.get_model("pantry", "StockItem")
+
+    for ingredient in list(Ingredient.objects.all()):
+        capitalised = ingredient.name.strip().capitalize()
+        if capitalised == ingredient.name:
+            continue
+
+        try:
+            existing = Ingredient.objects.get(name=capitalised)
+            # Redirect all StockItems to the existing record, then remove the duplicate
+            StockItem.objects.filter(ingredient=ingredient).update(ingredient=existing)
+            ingredient.delete()
+        except Ingredient.DoesNotExist:
+            ingredient.name = capitalised
+            ingredient.save()
+
+
+class Migration(migrations.Migration):
+
+    dependencies = [
+        ("pantry", "0004_cachedrecipe"),
+    ]
+
+    operations = [
+        migrations.RunPython(normalise_ingredient_names, reverse_code=migrations.RunPython.noop),
+    ]

--- a/pantry/models.py
+++ b/pantry/models.py
@@ -8,6 +8,10 @@ class Ingredient(models.Model):
     class Meta:
         ordering = ["name"]
 
+    def save(self, *args, **kwargs):
+        self.name = self.name.strip().capitalize()
+        super().save(*args, **kwargs)
+
     def __str__(self):
         return self.name
 

--- a/pantry/tests/test_models.py
+++ b/pantry/tests/test_models.py
@@ -27,6 +27,40 @@ class IngredientModelTest(TestCase):
         self.assertEqual(names, ["Apple", "Milk", "Zucchini"])
 
 
+class IngredientNormalisationTest(TestCase):
+
+    def test_lowercase_name_is_capitalised_on_create(self):
+        ing = Ingredient.objects.create(name="milk")
+        self.assertEqual(ing.name, "Milk")
+
+    def test_all_uppercase_is_normalised_on_create(self):
+        ing = Ingredient.objects.create(name="CHEESE")
+        self.assertEqual(ing.name, "Cheese")
+
+    def test_mixed_case_is_normalised_on_create(self):
+        ing = Ingredient.objects.create(name="eGGs")
+        self.assertEqual(ing.name, "Eggs")
+
+    def test_already_correct_case_is_unchanged(self):
+        ing = Ingredient.objects.create(name="Flour")
+        self.assertEqual(ing.name, "Flour")
+
+    def test_leading_trailing_whitespace_is_stripped(self):
+        ing = Ingredient.objects.create(name="  butter  ")
+        self.assertEqual(ing.name, "Butter")
+
+    def test_capitalisation_is_applied_on_update(self):
+        ing = Ingredient.objects.create(name="Flour")
+        ing.name = "oats"
+        ing.save()
+        ing.refresh_from_db()
+        self.assertEqual(ing.name, "Oats")
+
+    def test_multi_word_ingredient_only_capitalises_first_letter(self):
+        ing = Ingredient.objects.create(name="olive oil")
+        self.assertEqual(ing.name, "Olive oil")
+
+
 class StockItemModelTest(TestCase):
 
     def setUp(self):

--- a/pantry/tests/test_serializers.py
+++ b/pantry/tests/test_serializers.py
@@ -14,10 +14,10 @@ from pantry.serializers import (
 class IngredientSerializerTest(TestCase):
 
     def test_serializes_all_expected_fields(self):
-        ingredient = Ingredient.objects.create(name="Olive Oil")
+        ingredient = Ingredient.objects.create(name="Olive oil")
         data = IngredientSerializer(ingredient).data
         self.assertEqual(set(data.keys()), {"id", "name"})
-        self.assertEqual(data["name"], "Olive Oil")
+        self.assertEqual(data["name"], "Olive oil")
 
     def test_creates_ingredient_from_valid_data(self):
         serializer = IngredientSerializer(data={"name": "Butter"})


### PR DESCRIPTION
## Summary

This PR implements a data normalisation layer to all ingredient names for them to follow a consistent "Sentence case" format (capitalising the first letter).

## Type of change

- [ ] Bug fix
- [x] New feature
- [ ] Refactor (no functional change)
- [ ] Tests only
- [ ] Documentation
- [ ] Configuration / DevOps

## Related issue(s)

Closes #61

## Changes made

- Added `save()` override to the `Ingredient` model with `.strip().capitalize()` to `self.name`
- New data migration to capitalise historical records

## Testing

- [x] I have added or updated tests to cover my changes
- [x] All new and existing tests pass locally (`python manage.py test pantry`)
- [x] Test coverage has not dropped below 80 %
