### PR TITLE
Find recipes button

### DIFF
--- a/pantry/templates/pantry/recipes.html
+++ b/pantry/templates/pantry/recipes.html
@@ -222,7 +222,14 @@
     }).then(() => { window.location.href = '/login/'; });
   });
 
-  loadFavouriteIds();
-  loadProfileFilters();
+  // Await profile filters before any auto-trigger so dietary prefs are pre-applied
+  async function init() {
+    await loadProfileFilters();
+    loadFavouriteIds();
+    if (new URLSearchParams(window.location.search).get('autoload') === '1') {
+      document.getElementById('btn-find-recipes').click();
+    }
+  }
+  init();
 </script>
 {% endblock %}

--- a/pantry/templates/pantry/stock.html
+++ b/pantry/templates/pantry/stock.html
@@ -36,9 +36,12 @@
   <!-- Inventory table -->
   <div class="d-flex justify-content-between align-items-center mb-3">
     <h5 class="fw-bold mb-0">Current Inventory</h5>
-    <button class="btn btn-primary btn-sm" id="btn-add-item" data-bs-toggle="modal" data-bs-target="#itemModal">
-      + Add Item
-    </button>
+    <div class="d-flex gap-2">
+      <a href="/recipes/?autoload=1" class="btn btn-success btn-sm">Find Recipes</a>
+      <button class="btn btn-primary btn-sm" id="btn-add-item" data-bs-toggle="modal" data-bs-target="#itemModal">
+        + Add Item
+      </button>
+    </div>
   </div>
 
   <div class="table-responsive">

--- a/pantry/tests/test_views.py
+++ b/pantry/tests/test_views.py
@@ -490,6 +490,16 @@ class PantryPageViewTest(TestCase):
         self.assertIn("unit_choices", response.context)
         self.assertTrue(len(response.context["unit_choices"]) > 0)
 
+    def test_find_recipes_button_links_to_recipes_page_with_autoload(self):
+        self.client.force_login(self.user)
+        response = self.client.get(self.url)
+        self.assertContains(response, '/recipes/?autoload=1')
+
+    def test_find_recipes_button_is_rendered(self):
+        self.client.force_login(self.user)
+        response = self.client.get(self.url)
+        self.assertContains(response, 'Find Recipes')
+
 
 class RecipeDetailViewTest(APITestCase):
 


### PR DESCRIPTION
## Summary

This PR integrates a primary "Find Recipes" action button into the My Stock dashboard.

## Type of change

- [ ] Bug fix
- [x] New feature 
- [ ] Refactor (no functional change)
- [ ] Tests only
- [ ] Documentation
- [ ] Configuration / DevOps

## Related issue(s)

Closes #62 

## Changes made

- 
- Added `Find Recipes` button next to `+ Add Item` button on "My Stock" view
- Replaced the `loadFavouriteIds(); loadProfileFilters();` calls at the bottom with an async function so that the user's saved dietary preferences are checked before the auto-search fires
- `loadFavouriteIds()` is called in parallel (not awaited) since it only affects heart button state, not the search result

## Testing

- [x] I have added or updated tests to cover my changes
- [x] All new and existing tests pass locally (`python manage.py test pantry`)
- [x] Test coverage has not dropped below 80 %

