### PR TITLE
Fixed date issue

### DIFF
--- a/pantry/templates/pantry/stock.html
+++ b/pantry/templates/pantry/stock.html
@@ -178,7 +178,8 @@
     const tbody = document.getElementById('stock-tbody');
     const today = new Date(); today.setHours(0, 0, 0, 0);
     const nextWeek = new Date(today); nextWeek.setDate(today.getDate() + 7);
-    const todayStr = today.toISOString().slice(0, 10);
+    // Use the UTC date to match the timezone-aware created_at returned by the API
+    const todayStr = new Date().toISOString().slice(0, 10);
 
     let total = items.length;
     let expiring = 0;

--- a/pantry/tests/test_views.py
+++ b/pantry/tests/test_views.py
@@ -138,7 +138,6 @@ class StockItemListCreateViewTest(APITestCase):
         date_part = str(created_at)[:10]
         datetime.date.fromisoformat(date_part)
 
-
     def test_create_stock_item_returns_201(self):
         response = self.client.post(
             self.url,

--- a/pantry/tests/test_views.py
+++ b/pantry/tests/test_views.py
@@ -127,6 +127,18 @@ class StockItemListCreateViewTest(APITestCase):
 
     # Create
 
+    def test_list_response_includes_created_at_as_utc_iso_string(self):
+        StockItem.objects.create(user=self.user, ingredient=self.flour, quantity=500)
+        response = self.client.get(self.url)
+        item = response.data["results"][0]
+        self.assertIn("created_at", item)
+        created_at = item["created_at"]
+        self.assertIsNotNone(created_at)
+        # Must be a string whose first 10 characters form a valid YYYY-MM-DD date.
+        date_part = str(created_at)[:10]
+        datetime.date.fromisoformat(date_part)
+
+
     def test_create_stock_item_returns_201(self):
         response = self.client.post(
             self.url,


### PR DESCRIPTION
## Summary

This PR resolves the issue where the "Added today" metric card on the dashboard failed to show the correct count

## Type of change

- [x] Bug fix
- [ ] New feature 
- [ ] Refactor (no functional change)
- [ ] Tests only
- [ ] Documentation
- [ ] Configuration / DevOps

## Related issue(s)

Closes #63 

## Changes made

- Replaced `today.toISOString().slice(0, 10);` with `new Date().toISOString().slice(0, 10);` to avoid timezone issues

## Testing

- [x] I have added or updated tests to cover my changes
- [x] All new and existing tests pass locally (`python manage.py test pantry`)
- [x] Test coverage has not dropped below 80 %

## Notes for reviewers

The root cause of the issue was that in `stock.html`'s `renderTable` function the comparison was:

```javascript
const today = new Date(); today.setHours(0, 0, 0, 0);   // midnight in local timezone
const todayStr = today.toISOString().slice(0, 10);         // converts to UTC and may be yesterday's date
```

`Date.setHours(0, 0, 0, 0)` sets the object to "local midnight". `toISOString()` then converts that "local midnight" to UTC. If a user is located in a UTC+ timezone (example: UTC+1, UTC+2, etc.) "local midnight' is behind UTC and the resulting UTC date is actually the previous calendar day

As `item.created_at` from the DRF API is a UTC ISO string (Django uses `USE_TZ = True`). Its `slice(0, 10)` gives today's UTC date. The comparison of "today in UTC" vs "yesterday in UTC" always fails and counter stays at 0

