### PR TITLE
Feature/75 select ingredients

### DIFF
--- a/pantry/services.py
+++ b/pantry/services.py
@@ -72,10 +72,44 @@ def _search_cache_key(ingredient_names: list[str], diets: list[str] | None) -> s
     return f"recipe_search:{hex_digest}"
 
 
+def _recalculate_used_missed(results: list[dict], full_pantry_names: list[str] | None) -> list[dict]:
+    """
+    When only a subset of pantry ingredients is sent to Spoonacular, the API
+    will classify pantry items that weren't included in the query as "missed"
+    This function corrects the used/missed count by checking
+    each recipe's missed_ingredients against the user's full pantry.
+
+    If `full_pantry_names` is None (meaning the full pantry was already sent to
+    Spoonacular), the results are returned unchanged.
+    """
+    if not full_pantry_names:
+        return results
+
+    full_set = {name.lower() for name in full_pantry_names}
+    adjusted = []
+    for recipe in results:
+        used = list(recipe["used_ingredients"])
+        missed = []
+        for name in recipe["missed_ingredients"]:
+            if name.lower() in full_set:
+                used.append(name)
+            else:
+                missed.append(name)
+        adjusted.append({
+            **recipe,
+            "used_ingredients": used,
+            "missed_ingredients": missed,
+            "used_count": len(used),
+            "missed_count": len(missed),
+        })
+    return adjusted
+
+
 def find_recipes_by_ingredients(
     ingredient_names: list[str],
     number: int = 12,
     diets: list[str] | None = None,
+    full_pantry_names: list[str] | None = None,
 ) -> list[dict]:
     """
     Request to Spoonacular API for recipes suggested by the provided ingredient names and optional dietary filters.
@@ -85,10 +119,14 @@ def find_recipes_by_ingredients(
     `fillIngredients=true` so the same used/missed ingredient counts are returned.
 
     Args:
-        ingredient_names  - List of ingredient name strings from the user's pantry.
+        ingredient_names  - List of selected ingredient names from the user's pantry.
         number            - Maximum number of recipes to return (defaults to 12).
         diets             - Optional list of UserProfile dietary preference keys
                             (e.g. ["vegan", "gluten_free"]).
+        full_pantry_names - When `ingredient_names` is a subset of the user's
+                            pantry, pass the full list here so that used/missed
+                            counts are recalculated against the complete inventory
+                            rather than only the selected ingredients.
 
     Returns a list of recipe dicts, each containing:
             id, title, image, used_count, missed_count,
@@ -105,7 +143,7 @@ def find_recipes_by_ingredients(
     cache_key = _search_cache_key(ingredient_names, diets)
     cached = cache.get(cache_key)
     if cached is not None:
-        return cached
+        return _recalculate_used_missed(cached, full_pantry_names)
 
     use_complex_search = bool(diets)
 
@@ -165,7 +203,7 @@ def find_recipes_by_ingredients(
     # Store result on cache for the defined time on SEARCH_CACHE_TTL
     cache.set(cache_key, results, timeout=settings.SEARCH_CACHE_TTL)
 
-    return results
+    return _recalculate_used_missed(results, full_pantry_names)
 
 
 def get_recipe_details(recipe_id: int) -> dict:

--- a/pantry/templates/pantry/pantry.html
+++ b/pantry/templates/pantry/pantry.html
@@ -37,7 +37,7 @@
   <div class="d-flex justify-content-between align-items-center mb-3">
     <h5 class="fw-bold mb-0">Current Inventory</h5>
     <div class="d-flex gap-2">
-      <a href="/recipes/?autoload=1" class="btn btn-success btn-sm">Find Recipes</a>
+      <button class="btn btn-success btn-sm" id="btn-open-ingredient-modal">Find Recipes</button>
       <button class="btn btn-primary btn-sm" id="btn-add-item" data-bs-toggle="modal" data-bs-target="#itemModal">
         + Add Item
       </button>
@@ -132,6 +132,37 @@
       <div class="modal-footer">
         <button type="button" class="btn btn-secondary btn-sm" data-bs-dismiss="modal">Cancel</button>
         <button type="button" class="btn btn-danger btn-sm" id="confirm-delete-btn">Delete</button>
+      </div>
+    </div>
+  </div>
+</div>
+
+<!-- Ingredient selection modal -->
+<div class="modal fade" id="ingredientModal" tabindex="-1" aria-labelledby="ingredientModalLabel" aria-hidden="true">
+  <div class="modal-dialog modal-lg">
+    <div class="modal-content">
+      <div class="modal-header">
+        <h5 class="modal-title" id="ingredientModalLabel">Select Ingredients for Recipe Search</h5>
+        <button type="button" class="btn-close" data-bs-dismiss="modal"></button>
+      </div>
+      <div class="modal-body">
+        <div class="d-flex gap-2 mb-3">
+          <input type="text" class="form-control form-control-sm" id="ingredient-filter"
+                 placeholder="Search ingredients..." autocomplete="off">
+          <button type="button" class="btn btn-outline-secondary btn-sm text-nowrap" id="btn-select-all">
+            Select All
+          </button>
+        </div>
+        <p class="text-muted small mb-2">
+          <span id="selection-count" class="fw-semibold">0</span> ingredient(s) selected
+        </p>
+        <div id="ingredient-checklist" class="row g-2" style="max-height:300px; overflow-y:auto;">
+          <p class="text-muted">No ingredients in your pantry yet.</p>
+        </div>
+      </div>
+      <div class="modal-footer">
+        <button type="button" class="btn btn-secondary" data-bs-dismiss="modal">Cancel</button>
+        <button type="button" class="btn btn-success" id="btn-find-recipes-submit">Find Recipes</button>
       </div>
     </div>
   </div>
@@ -392,6 +423,92 @@
       credentials: 'same-origin',
       headers: { 'X-CSRFToken': getCsrf() },
     }).then(() => { window.location.href = '/login/'; });
+  });
+
+
+  // Ingredient Selection Modal
+
+  const ingredientModal = new bootstrap.Modal(document.getElementById('ingredientModal'));
+
+  function updateSelectionCount() {
+    const total = document.querySelectorAll('.ing-check').length;
+    const checked = document.querySelectorAll('.ing-check:checked').length;
+    document.getElementById('selection-count').textContent = checked;
+    // Toggle "Select All" label if everything is checked
+    document.getElementById('btn-select-all').textContent =
+      checked === total && total > 0 ? 'Deselect All' : 'Select All';
+  }
+
+  function buildChecklist(filterText) {
+    const checklist = document.getElementById('ingredient-checklist');
+    const q = (filterText || '').toLowerCase();
+
+    if (allItems.length === 0) {
+      checklist.innerHTML = '<p class="text-muted col-12">No ingredients in your pantry yet.</p>';
+      return;
+    }
+
+    // Preserve checked state across filter changes
+    const checked = new Set(
+      Array.from(document.querySelectorAll('.ing-check:checked')).map(cb => cb.value)
+    );
+
+    checklist.innerHTML = '';
+    allItems.forEach(item => {
+      const name = item.ingredient.name;
+      if (q && !name.toLowerCase().includes(q)) return;
+
+      const isChecked = checked.size === 0 || checked.has(name);
+      const col = document.createElement('div');
+      col.className = 'col-sm-6 col-md-4';
+      col.innerHTML = `
+        <div class="form-check">
+          <input class="form-check-input ing-check" type="checkbox"
+                 id="ing-${item.id}" value="${name}" ${isChecked ? 'checked' : ''}>
+          <label class="form-check-label text-truncate d-block" for="ing-${item.id}"
+                 title="${name}">${name}</label>
+        </div>`;
+      checklist.appendChild(col);
+    });
+
+    // Re-attach change listeners
+    document.querySelectorAll('.ing-check').forEach(cb =>
+      cb.addEventListener('change', updateSelectionCount)
+    );
+    updateSelectionCount();
+  }
+
+  document.getElementById('btn-open-ingredient-modal').addEventListener('click', () => {
+    // Reset filter and rebuild from current allItems
+    document.getElementById('ingredient-filter').value = '';
+    buildChecklist('');
+    ingredientModal.show();
+  });
+
+  document.getElementById('ingredient-filter').addEventListener('input', e => {
+    buildChecklist(e.target.value);
+  });
+
+  document.getElementById('btn-select-all').addEventListener('click', () => {
+    const checkboxes = document.querySelectorAll('.ing-check');
+    const allChecked = Array.from(checkboxes).every(cb => cb.checked);
+    checkboxes.forEach(cb => { cb.checked = !allChecked; });
+    updateSelectionCount();
+  });
+
+  document.getElementById('btn-find-recipes-submit').addEventListener('click', () => {
+    const selected = Array.from(document.querySelectorAll('.ing-check:checked'))
+      .map(cb => cb.value);
+
+    if (selected.length === 0) return;
+
+    const params = new URLSearchParams({ autoload: '1' });
+    // Only pass ?ingredients= when the selection is a subset
+    if (selected.length < allItems.length) {
+      params.set('ingredients', selected.join(','));
+    }
+    ingredientModal.hide();
+    window.location.href = `/recipes/?${params.toString()}`;
   });
 
 

--- a/pantry/templates/pantry/recipes.html
+++ b/pantry/templates/pantry/recipes.html
@@ -190,9 +190,9 @@
     document.getElementById('empty-state').classList.add('d-none');
 
     const selectedDiets = getSelectedDiets();
-    const url = selectedDiets.length
-      ? `${MATCH_URL}?diets=${encodeURIComponent(selectedDiets.join(','))}`
-      : MATCH_URL;
+    const params = new URLSearchParams();
+    if (selectedDiets.length) params.set('diets', selectedDiets.join(','));
+    const url = `${MATCH_URL}${params.toString() ? '?' + params.toString() : ''}`;
 
     try {
       const resp = await fetch(url, { credentials: 'same-origin' });
@@ -226,8 +226,39 @@
   async function init() {
     await loadProfileFilters();
     loadCookbookIds();
-    if (new URLSearchParams(window.location.search).get('autoload') === '1') {
+
+    const urlParams = new URLSearchParams(window.location.search);
+    if (urlParams.get('autoload') !== '1') return;
+
+    const ingParam = urlParams.get('ingredients');
+    if (!ingParam) {
       document.getElementById('btn-find-recipes').click();
+      return;
+    }
+
+    // Partial-ingredient autoload: build API call with ?ingredients=
+    clearAlert();
+    setLoading(true);
+    document.getElementById('recipe-grid').innerHTML = '';
+    document.getElementById('empty-state').classList.add('d-none');
+
+    const params = new URLSearchParams({ ingredients: ingParam });
+    const selectedDiets = getSelectedDiets();
+    if (selectedDiets.length) params.set('diets', selectedDiets.join(','));
+
+    try {
+      const resp = await fetch(`${MATCH_URL}?${params.toString()}`, { credentials: 'same-origin' });
+      const data = await resp.json();
+      if (!resp.ok) {
+        showAlert(data.detail || 'An error occurred while fetching recipes.', resp.status === 429 ? 'warning' : 'danger');
+        return;
+      }
+      if (data.detail) { showAlert(data.detail, 'info'); return; }
+      renderRecipes(data);
+    } catch {
+      showAlert('Could not reach the recipe service. Please check your connection and try again.');
+    } finally {
+      setLoading(false);
     }
   }
   init();

--- a/pantry/tests/test_views.py
+++ b/pantry/tests/test_views.py
@@ -519,15 +519,45 @@ class PantryPageViewTest(TestCase):
         self.assertIn("unit_choices", response.context)
         self.assertTrue(len(response.context["unit_choices"]) > 0)
 
-    def test_find_recipes_button_links_to_recipes_page_with_autoload(self):
+    def test_find_recipes_opens_ingredient_modal(self):
         self.client.force_login(self.user)
         response = self.client.get(self.url)
-        self.assertContains(response, '/recipes/?autoload=1')
+        self.assertContains(response, 'id="btn-open-ingredient-modal"')
 
     def test_find_recipes_button_is_rendered(self):
         self.client.force_login(self.user)
         response = self.client.get(self.url)
         self.assertContains(response, 'Find Recipes')
+
+    def test_ingredient_modal_is_present(self):
+        self.client.force_login(self.user)
+        response = self.client.get(self.url)
+        self.assertContains(response, 'id="ingredientModal"')
+
+    def test_ingredient_modal_has_search_filter(self):
+        self.client.force_login(self.user)
+        response = self.client.get(self.url)
+        self.assertContains(response, 'id="ingredient-filter"')
+
+    def test_ingredient_modal_has_select_all_button(self):
+        self.client.force_login(self.user)
+        response = self.client.get(self.url)
+        self.assertContains(response, 'id="btn-select-all"')
+
+    def test_ingredient_modal_has_checklist_container(self):
+        self.client.force_login(self.user)
+        response = self.client.get(self.url)
+        self.assertContains(response, 'id="ingredient-checklist"')
+
+    def test_ingredient_modal_has_selection_count(self):
+        self.client.force_login(self.user)
+        response = self.client.get(self.url)
+        self.assertContains(response, 'id="selection-count"')
+
+    def test_ingredient_modal_has_submit_button(self):
+        self.client.force_login(self.user)
+        response = self.client.get(self.url)
+        self.assertContains(response, 'id="btn-find-recipes-submit"')
 
 
 class RecipeDetailViewTest(APITestCase):

--- a/pantry/views.py
+++ b/pantry/views.py
@@ -86,20 +86,44 @@ class RecipeMatchView(APIView):
         diets_param = request.query_params.get("diets", "").strip()
         diets = [d.strip() for d in diets_param.split(",") if d.strip()] or None
 
-        ingredient_names = list(
+        all_stock = (
             StockItem.objects.filter(user=request.user)
             .select_related("ingredient")
             .values_list("ingredient__name", flat=True)
         )
+        all_names = list(all_stock)
 
-        if not ingredient_names:
+        if not all_names:
             return Response(
                 {"detail": "Your pantry is empty. Add some ingredients to get recipe suggestions."},
                 status=status.HTTP_200_OK,
             )
 
+        # Optional partial selection: ?ingredients=Flour,Milk
+        selected_param = request.query_params.get("ingredients", "").strip()
+        if selected_param:
+            selected = [s.strip() for s in selected_param.split(",") if s.strip()]
+            pantry_lower = {n.lower() for n in all_names}
+            ingredient_names = [n for n in selected if n.lower() in pantry_lower]
+            # Only pass full_pantry_names when the selection is a subset,
+            # so the service can recalculate used/missed against the real pantry.
+            full_pantry_names = all_names if len(ingredient_names) < len(all_names) else None
+        else:
+            ingredient_names = all_names
+            full_pantry_names = None
+
+        if not ingredient_names:
+            return Response(
+                {"detail": "None of the selected ingredients are in your pantry."},
+                status=status.HTTP_200_OK,
+            )
+
         try:
-            recipes = find_recipes_by_ingredients(ingredient_names, diets=diets)
+            recipes = find_recipes_by_ingredients(
+                ingredient_names,
+                diets=diets,
+                full_pantry_names=full_pantry_names,
+            )
         except SpoonacularError as e:
             http_status = status.HTTP_503_SERVICE_UNAVAILABLE
             if e.status_code == 402:


### PR DESCRIPTION
## Summary

This PR enhances the "Find Recipes" feature by introducing a selection interface. Users can now choose specific ingredients from their pantry to include in the search instead of always using their entire inventory.

## Type of change

- [ ] Bug fix
- [x] New feature 
- [ ] Refactor (no functional change)
- [ ] Tests only
- [ ] Documentation
- [ ] Configuration / DevOps

## Related issue(s)

Closes #75 

## Changes made


- Added `full_pantry_names` parameter to `find_recipes_by_ingredients`.
- Added `_recalculate_used_missed` helper that recalculates used/missed ingredients based on the full pantry set.
- `RecipeMatchView` now accepts an `ingredients` query parameter.
- Passes `full_pantry_names` to the service only when the selection is a subset  of the pantry
- Added HTML modal to select Ingredients

## Testing

- [x] I have added or updated tests to cover my changes
- [x] All new and existing tests pass locally (`python manage.py test`)
- [x] Test coverage has not dropped below 80 %
