### PR TITLE
Python set to 3.14

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -21,7 +21,7 @@ jobs:
 
       - uses: actions/setup-python@v6
         with:
-          python-version: "3.12"
+          python-version: "3.14"
           cache: "pip"
 
       - name: Install Flake8
@@ -74,7 +74,7 @@ jobs:
 
       - uses: actions/setup-python@v6
         with:
-          python-version: "3.12"
+          python-version: "3.14"
           cache: "pip"
 
       - name: Install Bandit


### PR DESCRIPTION
## Summary

This PR set all python versions on `ci.yml` to 3.14

## Type of change

- [ ] Bug fix
- [ ] New feature 
- [ ] Refactor (no functional change)
- [ ] Tests only
- [ ] Documentation
- [x] Configuration / DevOps

## Related issue(s)

Closes #107 

## Changes made

- Changed all python versions on `ci.yml` to 3.14

## Testing

- [x] I have added or updated tests to cover my changes
- [x] All new and existing tests pass locally (`python manage.py test`)
- [x] Test coverage has not dropped below 80 %
